### PR TITLE
feature/63-mock-name-main into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,6 +197,11 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] Exceptions now listed in alphabetical order ([#59][]).
 
 
+### Utils
+- [Added] `bypass_for_test()` added to allow mocking to be able to enter blocks
+      of code otherwise not easily reachable, if at all ([#63][]).
+
+
 ### Web: Backend / Meta
 
 ##### Unit Tests: Standard
@@ -270,6 +275,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#48][]
 - [#55][]
 - [#59][]
+- [#63][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -290,6 +296,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#56][] for [#55][]
 - [#60][] for [#59][]
 - [#61][] for [#11][]
+- [#64][] for [#63][]
 
 
 ---
@@ -315,6 +322,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#55]: https://github.com/JonathanCasey/grand_trade_auto/issues/55 'Issue #55'
 [#59]: https://github.com/JonathanCasey/grand_trade_auto/issues/59 'Issue #59'
 [#11]: https://github.com/JonathanCasey/grand_trade_auto/issues/11 'Issue #11'
+[#63]: https://github.com/JonathanCasey/grand_trade_auto/issues/63 'Issue #63'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -334,3 +342,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#56]: https://github.com/JonathanCasey/grand_trade_auto/pull/56 'PR #56'
 [#60]: https://github.com/JonathanCasey/grand_trade_auto/pull/60 'PR #60'
 [#61]: https://github.com/JonathanCasey/grand_trade_auto/pull/61 'PR #61'
+[#64]: https://github.com/JonathanCasey/grand_trade_auto/pull/64 'PR #64'

--- a/grand_trade_auto/general/__init__.py
+++ b/grand_trade_auto/general/__init__.py
@@ -4,4 +4,5 @@ __all__ = [
         'dirs',
         'email_report',
         'exceptions',
+        'utils',
 ]

--- a/grand_trade_auto/general/utils.py
+++ b/grand_trade_auto/general/utils.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""
+General utilities for items that are reused, but not enough in a single
+category to separate into its own file/module.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+
+
+
+def bypass_name_main_for_test(mod_or_meth_ref, sub_id): # pylint: disable=unused-argument
+    """
+    This is purposely hardcoded to always return false.  It is intended to be
+    called as an 'or' condition in any `if __name__ == '__main__'` conditionals
+    where unit testing is needed.
+
+    In unit tests, this method can be mocked and replaced with a body that
+    returns true for the specific location(s) required by checking both the
+    `mod_or_meth_ref` and `sub_id` match together.
+
+    Args:
+      mod_or_meth_ref (function/str/?): A unique reference to a module or
+        method.  For methods, passing the reference to the method itself (i.e.
+        its name without the `()` to call it) is recommended.  For modules,
+        `__name__` works since this is intended to only be used in conjunction
+        with cases where the `__name__` being `__main__` is covered by the other
+        part of the `if` statement (see above).  Alternative approaches are
+        possible so long as they are unique within the project.
+      sub_id (int/str/?): Some sort of unique identifier.  This only needs to be
+        unique within the scope of the module or method referenced, as the
+        module or method reference will create a sort of "namespace" for the
+        `sub_id`.
+
+    Returns:
+      (bool): Always returns False.  Only unit test mocking may change this.
+    """
+    return False

--- a/grand_trade_auto/general/utils.py
+++ b/grand_trade_auto/general/utils.py
@@ -11,7 +11,7 @@ Module Attributes:
 
 
 
-def bypass_for_test(mod_or_meth_ref, sub_id):  # pylint: disable=unused-argument
+def bypass_for_test(scope_ref, sub_id):  # pylint: disable=unused-argument
     """
     This is purposely hardcoded to always return false.  It is intended to be
     called as an 'or' condition in any `if __name__ == '__main__'` conditionals
@@ -20,7 +20,14 @@ def bypass_for_test(mod_or_meth_ref, sub_id):  # pylint: disable=unused-argument
 
     In unit tests, this method can be mocked and replaced with a body that
     returns true for the specific location(s) required by checking both the
-    `mod_or_meth_ref` and `sub_id` match together.
+    `scope_ref` and `sub_id` match together.
+
+    The `scope_ref` can take many forms, but should be consistent within each
+    category and as long as designed properly, should avoid collisions by
+    design.  These categories and recommended references are:
+     - method: Reference to the method itself (i.e. its name without the `()`)
+     - class: Reference to the class itself
+     - module: `__name__` (str), which for unit tests will avoid `__main__`
 
     While this does allow module references, it is highly recommended to avoid
     this, as it will require reloading the module.  If really necessary, it can
@@ -29,18 +36,20 @@ def bypass_for_test(mod_or_meth_ref, sub_id):  # pylint: disable=unused-argument
     for things at module scope is harder given how spread out this can be, but
     this is easier to solve.  Could probably even be checked with CI...
 
+    Similarly, class references (e.g. using logic for whether to define a class
+    attribute or not) are also recommended to avoid for the same reasons.  If
+    needed, the same solution of reloading the module should do the trick, but
+    is untested.
+
     Args:
-      mod_or_meth_ref (function/str/?): A unique reference to a module or
-        method.  For methods, passing the reference to the method itself (i.e.
-        its name without the `()` to call it) is recommended.  For modules,
-        `__name__` usually works since this is intended to primarily be used in
-        conjunction with cases where the `__name__` being `__main__` is covered
-        by the other part of the `if` statement (see above).  Alternative
-        approaches are possible so long as they are unique within the project.
+      scope_ref (function/class/str/?): A unique reference to a method, class,
+        or module.  See above for recommended references.  Alternative scope
+        categories and/or approaches are possible so long as they are unique
+        within this project and will not collide with other scope categories.
       sub_id (int/str/?): Some sort of unique identifier.  This only needs to be
-        unique within the scope of the module or method referenced, as the
-        module or method reference will create a sort of "namespace" for the
-        `sub_id`.
+        unique within the scope of the method/class/module/etc referenced, as
+        the method/class/module/etc reference will create a sort of "namespace"
+        for the `sub_id`.
 
     Returns:
       (bool): Always returns False.  Only unit test mocking may change this.

--- a/grand_trade_auto/general/utils.py
+++ b/grand_trade_auto/general/utils.py
@@ -24,7 +24,10 @@ def bypass_for_test(mod_or_meth_ref, sub_id):  # pylint: disable=unused-argument
 
     While this does allow module references, it is highly recommended to avoid
     this, as it will require reloading the module.  If really necessary, it can
-    be done likely with something like `importlib.reload(package_name)`.
+    be done likely with something like `importlib.reload(package_name)`.  To a
+    much lesser degree, it is also discouraged because ensuring unique `sub_id`s
+    for things at module scope is harder given how spread out this can be, but
+    this is easier to solve.  Could probably even be checked with CI...
 
     Args:
       mod_or_meth_ref (function/str/?): A unique reference to a module or

--- a/grand_trade_auto/general/utils.py
+++ b/grand_trade_auto/general/utils.py
@@ -11,24 +11,29 @@ Module Attributes:
 
 
 
-def bypass_name_main_for_test(mod_or_meth_ref, sub_id): # pylint: disable=unused-argument
+def bypass_for_test(mod_or_meth_ref, sub_id):  # pylint: disable=unused-argument
     """
     This is purposely hardcoded to always return false.  It is intended to be
     called as an 'or' condition in any `if __name__ == '__main__'` conditionals
-    where unit testing is needed.
+    where unit testing is needed or similar situtions where mocking is
+    difficult.
 
     In unit tests, this method can be mocked and replaced with a body that
     returns true for the specific location(s) required by checking both the
     `mod_or_meth_ref` and `sub_id` match together.
 
+    While this does allow module references, it is highly recommended to avoid
+    this, as it will require reloading the module.  If really necessary, it can
+    be done likely with something like `importlib.reload(package_name)`.
+
     Args:
       mod_or_meth_ref (function/str/?): A unique reference to a module or
         method.  For methods, passing the reference to the method itself (i.e.
         its name without the `()` to call it) is recommended.  For modules,
-        `__name__` works since this is intended to only be used in conjunction
-        with cases where the `__name__` being `__main__` is covered by the other
-        part of the `if` statement (see above).  Alternative approaches are
-        possible so long as they are unique within the project.
+        `__name__` usually works since this is intended to primarily be used in
+        conjunction with cases where the `__name__` being `__main__` is covered
+        by the other part of the `if` statement (see above).  Alternative
+        approaches are possible so long as they are unique within the project.
       sub_id (int/str/?): Some sort of unique identifier.  This only needs to be
         unique within the scope of the module or method referenced, as the
         module or method reference will create a sort of "namespace" for the

--- a/tests/unit/general/__init__.py
+++ b/tests/unit/general/__init__.py
@@ -3,4 +3,5 @@ __all__ = [
         'test_config',
         'test_dirs',
         'test_email_report',
+        'test_utils',
 ]

--- a/tests/unit/general/test_utils.py
+++ b/tests/unit/general/test_utils.py
@@ -16,29 +16,28 @@ from grand_trade_auto.general import utils
 
 
 
-def test_bypass_name_main_for_test(monkeypatch):
+def test_bypass_for_test(monkeypatch):
     """
     Tests `bypass_name_main_for_test()`.
     """
-    assert not utils.bypass_name_main_for_test(test_bypass_name_main_for_test,
+    assert not utils.bypass_for_test(test_bypass_for_test,
             1)
 
-    def allow_test_bypass_name_main_for_test(mod_or_meth_ref, sub_id):
+    def allow_test_bypass_for_test(mod_or_meth_ref, sub_id):
         """
+        Will allow a specific case to pass in order to test bypass.
+
+        Args: Same as utils.bypass_for_test().
         """
-        if mod_or_meth_ref == test_bypass_name_main_for_test \
+        if mod_or_meth_ref == test_bypass_for_test \
                 and sub_id == 2:   # pylint: disable=comparison-with-callable
             return True
         return False
 
-    original_bypass_name_main_for_test = utils.bypass_name_main_for_test
-    monkeypatch.setattr(utils, 'bypass_name_main_for_test',
-            allow_test_bypass_name_main_for_test)
-    assert not utils.bypass_name_main_for_test(test_bypass_name_main_for_test,
-            1)
-    assert utils.bypass_name_main_for_test(test_bypass_name_main_for_test, 2)
+    original_bypass_for_test = utils.bypass_for_test
+    monkeypatch.setattr(utils, 'bypass_for_test', allow_test_bypass_for_test)
+    assert not utils.bypass_for_test(test_bypass_for_test, 1)
+    assert utils.bypass_for_test(test_bypass_for_test, 2)
 
-    monkeypatch.setattr(utils, 'bypass_name_main_for_test',
-            original_bypass_name_main_for_test)
-    assert not utils.bypass_name_main_for_test(test_bypass_name_main_for_test,
-            2)
+    monkeypatch.setattr(utils, 'bypass_for_test', original_bypass_for_test)
+    assert not utils.bypass_for_test(test_bypass_for_test, 2)

--- a/tests/unit/general/test_utils.py
+++ b/tests/unit/general/test_utils.py
@@ -18,7 +18,7 @@ from grand_trade_auto.general import utils
 
 def test_bypass_for_test(monkeypatch):
     """
-    Tests `bypass_name_main_for_test()`.
+    Tests `bypass_for_test()`.
     """
     assert not utils.bypass_for_test(test_bypass_for_test,
             1)

--- a/tests/unit/general/test_utils.py
+++ b/tests/unit/general/test_utils.py
@@ -23,13 +23,13 @@ def test_bypass_for_test(monkeypatch):
     assert not utils.bypass_for_test(test_bypass_for_test,
             1)
 
-    def allow_test_bypass_for_test(mod_or_meth_ref, sub_id):
+    def allow_test_bypass_for_test(scope_ref, sub_id):
         """
         Will allow a specific case to pass in order to test bypass.
 
         Args: Same as utils.bypass_for_test().
         """
-        if mod_or_meth_ref == test_bypass_for_test \
+        if scope_ref == test_bypass_for_test \
                 and sub_id == 2:   # pylint: disable=comparison-with-callable
             return True
         return False

--- a/tests/unit/general/test_utils.py
+++ b/tests/unit/general/test_utils.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""
+Tests the grand_trade_auto.general.dirs functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+from grand_trade_auto.general import utils
+
+
+
+def test_bypass_name_main_for_test(monkeypatch):
+    """
+    Tests `bypass_name_main_for_test()`.
+    """
+    assert not utils.bypass_name_main_for_test(test_bypass_name_main_for_test,
+            1)
+
+    def allow_test_bypass_name_main_for_test(mod_or_meth_ref, sub_id):
+        """
+        """
+        if mod_or_meth_ref == test_bypass_name_main_for_test \
+                and sub_id == 2:   # pylint: disable=comparison-with-callable
+            return True
+        return False
+
+    original_bypass_name_main_for_test = utils.bypass_name_main_for_test
+    monkeypatch.setattr(utils, 'bypass_name_main_for_test',
+            allow_test_bypass_name_main_for_test)
+    assert not utils.bypass_name_main_for_test(test_bypass_name_main_for_test,
+            1)
+    assert utils.bypass_name_main_for_test(test_bypass_name_main_for_test, 2)
+
+    monkeypatch.setattr(utils, 'bypass_name_main_for_test',
+            original_bypass_name_main_for_test)
+    assert not utils.bypass_name_main_for_test(test_bypass_name_main_for_test,
+            2)


### PR DESCRIPTION
This adds a `bypass_for_test()` method that can be or'd with blocks of code that normally are unreachable / not easily mockable for unit testing, such as `if __name__ == '__main__'` conditionals.

This is not used anywhere yet; it simply adds the utility method so it can start being used as needed.

Closes #63.