### PR TITLE
feature/73-more-missing-extensions into develop

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,13 @@ trim_trailing_whitespace = true
 [.coveragerc]
 indent_size = 4
 
+[.editorconfig]
+indent_size = 4
+
 [.gitattributes]
+indent_size = 4
+
+[.gitignore]
 indent_size = 4
 
 [.pylintrc]

--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,11 @@
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.
+.coveragerc     text    eol=lf
+.editorconfig   text    eol=lf
+.gitattributes  text    eol=lf
+.gitignore      text    eol=lf
+.pylintrc       text    eol=lf
 *.conf          text    eol=lf
 *.conf.ci       text    eol=lf
 *.conf.default  text    eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       ([#71][]).
 - [Added] `*.conf.ci`, `*.conf.default`, `*.env.default`, `*.jinja2`, `*.svg`,
       `*.txt`, `*.yaml`, `*.yml` added to `.gitattributes` ([#71][]).
+- [Added] `.editorconfig`, `.gitignore` added to `.editorconfig` ([#73][]).
+- [Added] `.coveragerc`, `.editorconfig`, `.gitattributes`, `.gitignore`, and
+      `.pylintrc` added to `.gitattributes` ([#73][]).
 
 
 ### Project & Toolchain: CircleCI
@@ -337,6 +340,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#66][]
 - [#67][]
 - [#71][]
+- [#73][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -362,6 +366,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#69][] for [#62][], [#67][]
 - [#70][] for [#58][]
 - [#72][] for [#71][]
+- [#74][] for [#73][]
 
 
 ---
@@ -393,6 +398,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#62]: https://github.com/JonathanCasey/grand_trade_auto/issues/62 'Issue #62'
 [#58]: https://github.com/JonathanCasey/grand_trade_auto/issues/58 'Issue #58'
 [#71]: https://github.com/JonathanCasey/grand_trade_auto/issues/71 'Issue #71'
+[#73]: https://github.com/JonathanCasey/grand_trade_auto/issues/73 'Issue #73'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -417,3 +423,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#69]: https://github.com/JonathanCasey/grand_trade_auto/pull/69 'PR #69'
 [#70]: https://github.com/JonathanCasey/grand_trade_auto/pull/70 'PR #70'
 [#72]: https://github.com/JonathanCasey/grand_trade_auto/pull/72 'PR #72'
+[#74]: https://github.com/JonathanCasey/grand_trade_auto/pull/74 'PR #74'


### PR DESCRIPTION
This adds some more missing extensions/files to `.editorconfig` and `gitattributes`.  This also ensures all files have been opened and re-saved to ensure they conform.

Fixes #73.