### PR TITLE
feature/7-54-add-datafeed-alpaca into develop

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,3 +16,4 @@ max-args=10
 [MESSAGE CONTROL]
 disable=
         logging-fstring-interpolation,
+        logging-not-lazy,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -416,6 +416,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#3][]
 - [#4][]
 - [#6][]
+- [#7][]
 - [#8][]
 - [#9][]
 - [#10][]
@@ -427,6 +428,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#39][]
 - [#45][]
 - [#48][]
+- [#54][]
 - [#55][]
 - [#58][]
 - [#59][]
@@ -466,6 +468,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#74][] for [#73][]
 - [#76][] for [#74][]
 - [#78][] for [#77][]
+- [#79][] for [#7][], [#54][]
 
 
 ---
@@ -500,6 +503,8 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#73]: https://github.com/JonathanCasey/grand_trade_auto/issues/73 'Issue #73'
 [#75]: https://github.com/JonathanCasey/grand_trade_auto/issues/75 'Issue #75'
 [#77]: https://github.com/JonathanCasey/grand_trade_auto/issues/77 'Issue #77'
+[#7]: https://github.com/JonathanCasey/grand_trade_auto/issues/7 'Issue #7'
+[#54]: https://github.com/JonathanCasey/grand_trade_auto/issues/54 'Issue #54'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -527,3 +532,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#74]: https://github.com/JonathanCasey/grand_trade_auto/pull/74 'PR #74'
 [#76]: https://github.com/JonathanCasey/grand_trade_auto/pull/76 'PR #76'
 [#78]: https://github.com/JonathanCasey/grand_trade_auto/pull/78 'PR #78'
+[#79]: https://github.com/JonathanCasey/grand_trade_auto/pull/79 'PR #79'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Added] Good names added to `.pylintrc`, with `v` being the critical addition
       to allow usage without pylint complaints ([#9][]).
 - [Added] `f` added to `good-names` list in `.pylintrc` ([#11][]).
+- [Added] `logging-not-lazy` added to global disable list in `.pylintrc` to
+     leave f-strings in logging to coder's choice ([#7][]).
 
 
 ### Project & Toolchain: Tmp Main
@@ -144,6 +146,9 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       class, does nothing with it ([#75][]).
 - [Changed] `_APIC_HANDLE` and other similar names shortened to `_APIC`
       ([#75][]).
+- [Changed] `Apic`'s `__init__()` no longer abstract ([#7][]).
+- [Added] `Apic`'s `__init__()` warns if unused kwargs not consumed prior
+      ([#7][]).
 
 
 ### APIC: Alpaca
@@ -152,6 +157,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] `Alpaca` constructor only explicitly takes its own args; also takes
       `kwargs` where all parent args expected, passed to `super()` constructor
       ([#75][]).
+- [Added] `Alpaca` now also inherits secondarily from `Datafeed` class ([#7][],
+      [#54][]).
 
 
 ### Brokers / Meta
@@ -230,6 +237,11 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Added] `DatabasePostgres` file and class started, with ability to load from
       config, connect, create/drop/check-exists DB ([#2][]).
 - [Added] Logging setup and logger usage added to existing code ([#8][]).
+
+
+### Datafeeds / Meta
+- [Added] `datafeed_meta` module added, includes `Datafeed` abstract class with
+      no real functionality yet ([#7][]).
 
 
 ### General: Config

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,14 +61,14 @@ are used (unless you really want to test with live trading / real money...).
 # Usage
 
 ## Logger
-Balancing readability against performance, the pylint warning
-`logging-fstring-interpolation` is disabled.  The intention is largerly for this
-to apply to warnings and more severe log levels as well as anything that would
-be low overhead.  It is recommended that anything info or debug level,
-especially if there are many calls or each call is an time-expensive
-interpolation to use the `logger.debug('log %(name)s', {'name'=name_var})` sort
-of methods instead so that the interpolation is only executed when that logger
-level is enabled.
+Balancing readability against performance, the pylint warnings
+`logging-fstring-interpolation` and `logging-not-lazy` are disabled.  The
+intention is largerly for this to apply to warnings and more severe log levels
+as well as anything that would be low overhead.  It is recommended that anything
+info or debug level, especially if there are many calls or each call is an
+time-expensive interpolation to use the
+`logger.debug('log %(name)s', {'name'=name_var})` sort of methods instead so
+that the interpolation is only executed when that logger level is enabled.
 
 
 ## Workflows

--- a/grand_trade_auto/apic/alpaca.py
+++ b/grand_trade_auto/apic/alpaca.py
@@ -13,6 +13,7 @@ import logging
 import alpaca_trade_api as tradeapi
 
 from grand_trade_auto.broker import broker_meta
+from grand_trade_auto.datafeed import datafeed_meta
 from grand_trade_auto.general import config
 
 
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 
-class Alpaca(broker_meta.Broker):
+class Alpaca(broker_meta.Broker, datafeed_meta.Datafeed):
     """
     The Alpaca broker API Client functionality.
 

--- a/grand_trade_auto/apic/apic_meta.py
+++ b/grand_trade_auto/apic/apic_meta.py
@@ -10,6 +10,11 @@ Module Attributes:
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 from abc import ABC, abstractmethod
+import logging
+
+
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -32,7 +37,6 @@ class Apic(ABC):
       _cp_secrets_id (str): The id used as the section name in the secrets
         conf.  Will be used for loading credentials on-demand.
     """
-    @abstractmethod
     def __init__(self, env, cp_apic_id, cp_secrets_id, **kwargs):
         """
         Creates the API Client.
@@ -47,6 +51,10 @@ class Apic(ABC):
         self._env = env
         self._cp_apic_id = cp_apic_id
         self._cp_secrets_id = cp_secrets_id
+
+        if kwargs:
+            logger.warning('Discarded excess kwargs provided to'
+                    + f' {self.__class__.__name__}: {", ".join(kwargs.keys())}')
 
 
 

--- a/grand_trade_auto/datafeed/__init__.py
+++ b/grand_trade_auto/datafeed/__init__.py
@@ -1,0 +1,4 @@
+# pylint: disable=missing-module-docstring
+__all__ = [
+        'datafeed_meta',
+]

--- a/grand_trade_auto/datafeed/datafeed_meta.py
+++ b/grand_trade_auto/datafeed/datafeed_meta.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""
+Holds the generic datafeed meta-class that others will subclass.  Any other
+shared datafeed code that needs to be accessed by all datafeeds can be
+implemented here so they have access when this is imported.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+from abc import ABC, abstractmethod
+
+from grand_trade_auto.apic import apic_meta
+
+
+
+class Datafeed(apic_meta.Apic, ABC):
+    """
+    The abstract class for all datafeed functionality.  Each datafeed type will
+    subclass this, but externally will likely only call the generic methods
+    defined here to unify the interface.
+
+    Class Attributes:
+      N/A
+
+    Instance Attributes:
+      [inherited from ApicMeta]:
+        _env (str): The run environment type valid for using this broker.
+        _cp_broker_id (str): The id used as the section name in the API Client
+          conf.  Will be used for loading credentials on-demand.
+        _cp_secrets_id (str): The id used as the section name in the secrets
+          conf.  Will be used for loading credentials on-demand.
+    """
+    @abstractmethod
+    def __init__(self, **kwargs):
+        """
+        Creates the datafeed handle.
+
+        Args:
+          See parent(s) for required kwargs.
+        """
+        super().__init__(**kwargs)

--- a/tests/unit/apic/__init__.py
+++ b/tests/unit/apic/__init__.py
@@ -1,5 +1,6 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
         'test_alpaca',
+        'test_apic_meta',
         'test_apics',
 ]

--- a/tests/unit/apic/test_apic_meta.py
+++ b/tests/unit/apic/test_apic_meta.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""
+Tests the grand_trade_auto.apic.apics functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+import logging
+
+from grand_trade_auto.apic import alpaca
+from grand_trade_auto.apic import apic_meta
+
+
+
+def test_apic_init(caplog):
+    """
+    Tests the `__init__()` method of `Apic`, at least for its unique
+    functionality that is not expected to be tested anywhere else.
+    """
+
+    class MockApicChild(apic_meta.Apic):
+        """"
+        Simple mock object to subclass Apic.
+        """
+
+        @classmethod
+        def load_from_config(cls, apic_cp, apic_id, secrets_id):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+        @classmethod
+        def get_provider_names(cls):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+        def connect(self):
+            """
+            Not needed / will not be used.
+            """
+            return
+
+    caplog.set_level(logging.WARNING)
+    caplog.clear()
+    MockApicChild('mock_env', 'mock_cp_apic_id', 'mock_cp_secrets_id')
+    assert caplog.record_tuples == []
+
+    extra_kwargs = {
+            'key1': 'val1',
+            'key2': 'val2',
+    }
+    caplog.clear()
+    MockApicChild('mock_env', 'mock_cp_apic_id', 'mock_cp_secrets_id',
+            **extra_kwargs)
+    assert caplog.record_tuples == [
+            ('grand_trade_auto.apic.apic_meta', logging.WARNING,
+                'Discarded excess kwargs provided to MockApicChild: key1, key2')
+    ]
+
+    # Using Alpaca to test grandchild with multiple/diamond inheritance pattern
+    kwargs = {
+        'env': 'mock_env',
+        'cp_apic_id': 'mock_cp_apic_id',
+        'cp_secrets_id': 'mock_cp_secrets_id',
+        **extra_kwargs,
+    }
+    caplog.clear()
+    alpaca.Alpaca('paper', **kwargs)
+    assert caplog.record_tuples == [
+            ('grand_trade_auto.apic.apic_meta', logging.WARNING,
+                'Discarded excess kwargs provided to Alpaca: key1, key2')
+    ]


### PR DESCRIPTION
This adds a `Datafeed` abstract class in a new `datafeed_meta` module.  `Alpaca` inherits this new class.  No new functionality added in this class yet, but now ready for it.

`Apic` now checks for extra unused `kwargs` in its `__init__()` (no longer abstract method) since this diamond inheritance now makes it even less obvious if extra unused kwargs have been provided.

Closes #7.  Also closes #54 (which is kind of just a duplicate of #7?).