### PR TITLE
feature/80-meta-db-remove into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -444,6 +444,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#73][]
 - [#75][]
 - [#77][]
+- [#80][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -473,6 +474,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#76][] for [#74][]
 - [#78][] for [#77][]
 - [#79][] for [#7][], [#54][]
+- [#83][] for [#80][]
 
 
 ---
@@ -509,6 +511,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#77]: https://github.com/JonathanCasey/grand_trade_auto/issues/77 'Issue #77'
 [#7]: https://github.com/JonathanCasey/grand_trade_auto/issues/7 'Issue #7'
 [#54]: https://github.com/JonathanCasey/grand_trade_auto/issues/54 'Issue #54'
+[#80]: https://github.com/JonathanCasey/grand_trade_auto/issues/80 'Issue #80'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -537,3 +540,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#76]: https://github.com/JonathanCasey/grand_trade_auto/pull/76 'PR #76'
 [#78]: https://github.com/JonathanCasey/grand_trade_auto/pull/78 'PR #78'
 [#79]: https://github.com/JonathanCasey/grand_trade_auto/pull/79 'PR #79'
+[#83]: https://github.com/JonathanCasey/grand_trade_auto/pull/83 'PR #83'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -231,12 +231,16 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       requirements ([#2][]).
 - [Added] `databases` file started, loads a default main database handle from
       config ([#2][]).
+- [Changed] `DatabaseMeta` is now simply `Database` ([#80][]).
 
 
 ### Database: Postgres
 - [Added] `DatabasePostgres` file and class started, with ability to load from
       config, connect, create/drop/check-exists DB ([#2][]).
 - [Added] Logging setup and logger usage added to existing code ([#8][]).
+- [Changed] `database_postgres` and `test_database_postgres` modules are now
+      simply `postgres` and `test_postgres`, respectively ([#80][]).
+- [Changed] `DatabasePostgres` is now simply `Postgres` ([#80][]).
 
 
 ### Datafeeds / Meta

--- a/grand_trade_auto/apic/alpaca.py
+++ b/grand_trade_auto/apic/alpaca.py
@@ -38,7 +38,7 @@ class Alpaca(broker_meta.Broker, datafeed_meta.Datafeed):
       _stream_conn (StreamConn): The cached stream socket connection; or None if
         not connected and cached.
 
-      [inherited from ApicMeta]:
+      [inherited from Apic]:
         _env (str): The run environment type valid for using this API Client.
         _cp_apic_id (str): The id used as the section name in the API Client
           conf.  Will be used for loading credentials on-demand.

--- a/grand_trade_auto/apic/apic_meta.py
+++ b/grand_trade_auto/apic/apic_meta.py
@@ -5,7 +5,7 @@ shared API Client access code that needs to be accessed regardless of which API
 can be implemented here so they have access when this is imported.
 
 Module Attributes:
-  N/A
+  logger (Logger): Logger for this module.
 
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """

--- a/grand_trade_auto/broker/broker_meta.py
+++ b/grand_trade_auto/broker/broker_meta.py
@@ -25,7 +25,7 @@ class Broker(apic_meta.Apic, ABC):
       N/A
 
     Instance Attributes:
-      [inherited from ApicMeta]:
+      [inherited from Apic]:
         _env (str): The run environment type valid for using this broker.
         _cp_broker_id (str): The id used as the section name in the API Client
           conf.  Will be used for loading credentials on-demand.

--- a/grand_trade_auto/database/__init__.py
+++ b/grand_trade_auto/database/__init__.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
         'database_meta',
-        'database_postgres',
         'databases',
+        'postgres',
 ]

--- a/grand_trade_auto/database/database_meta.py
+++ b/grand_trade_auto/database/database_meta.py
@@ -13,7 +13,7 @@ from abc import ABC, abstractmethod
 
 
 
-class DatabaseMeta(ABC):
+class Database(ABC):
     """
     The abstract class for all database functionality.  Each database type
     will subclass this, but externally will likely only call the generic methods
@@ -63,9 +63,8 @@ class DatabaseMeta(ABC):
             appears as the section header in the secrets_cp.
 
         Returns:
-          db_handle (DatabaseMeta<>): The DatabaseMeta<> object created and
-            loaded from config, where DatabaseMeta<> is a subclass of
-            DatabaseMeta (e.g. DatabasePostgres).
+          db_handle (Database<>): The Database<> object created and loaded from
+            config, where Database<> is a subclass of Database (e.g. Postgres).
         """
 
 

--- a/grand_trade_auto/database/databases.py
+++ b/grand_trade_auto/database/databases.py
@@ -4,12 +4,12 @@ The database API module.  This is intended to be the item accessed outside of
 the database submodule/folder.
 
 Module Attributes:
-  _DB_HANDLE (DatabaseMeta<>): The handle to the database that will be used,
-    where DatabaseMeta<> is a subclass of DatabaseMeta (e.g. DatabasePostgres).
+  _DB_HANDLE (Database<>): The handle to the database that will be used, where
+    Database<> is a subclass of Database (e.g. Postgres).
 
 (C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
 """
-from grand_trade_auto.database import database_postgres
+from grand_trade_auto.database import postgres
 from grand_trade_auto.general import config
 
 
@@ -63,13 +63,12 @@ def _get_database_from_config(env, db_type=None):
         secrets_id = config.get_matching_secrets_id(secrets_cp, 'database',
                 db_id)
 
-        postgres_type_names = \
-                database_postgres.DatabasePostgres.get_type_names()
+        postgres_type_names = postgres.Postgres.get_type_names()
         if db_cp[db_id]['type'].strip() in postgres_type_names:
             if db_type is not None and db_type not in postgres_type_names:
                 continue
 
-            db_handle = database_postgres.DatabasePostgres.load_from_config(
+            db_handle = postgres.Postgres.load_from_config(
                     db_cp, db_id, secrets_id)
 
             if db_handle is not None:

--- a/grand_trade_auto/database/postgres.py
+++ b/grand_trade_auto/database/postgres.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 
-class DatabasePostgres(database_meta.DatabaseMeta):
+class Postgres(database_meta.Database):
     """
     The PostgreSQL database functionality.
 
@@ -79,8 +79,8 @@ class DatabasePostgres(database_meta.DatabaseMeta):
             appears as the section header in the secrets_cp.
 
         Returns:
-          db_handle (DatabasePostgres): The DatabasePostgres object created and
-            loaded from config based on the provided config data.
+          db_handle (Postgres): The Postgres object created and loaded from
+            config based on the provided config data.
         """
         kwargs = {}
 
@@ -90,7 +90,7 @@ class DatabasePostgres(database_meta.DatabaseMeta):
         kwargs['cp_db_id'] = db_id
         kwargs['cp_secrets_id'] = secrets_id
 
-        db_handle = DatabasePostgres(**kwargs)
+        db_handle = Postgres(**kwargs)
         return db_handle
 
 

--- a/grand_trade_auto/datafeed/datafeed_meta.py
+++ b/grand_trade_auto/datafeed/datafeed_meta.py
@@ -25,7 +25,7 @@ class Datafeed(apic_meta.Apic, ABC):
       N/A
 
     Instance Attributes:
-      [inherited from ApicMeta]:
+      [inherited from Apic]:
         _env (str): The run environment type valid for using this broker.
         _cp_broker_id (str): The id used as the section name in the API Client
           conf.  Will be used for loading credentials on-demand.

--- a/tests/unit/database/__init__.py
+++ b/tests/unit/database/__init__.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
-        'test_database_postgres',
         'test_databases',
+        'test_postgres',
 ]

--- a/tests/unit/database/test_postgres.py
+++ b/tests/unit/database/test_postgres.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Tests the grand_trade_auto.general.database_postgres functionality.
+Tests the grand_trade_auto.general.postgres functionality.
 
 Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
 all tiles, classes, and methods will be prefaced with `test_/Test` to comply
@@ -17,7 +17,7 @@ Module Attributes:
 import psycopg2
 import pytest
 
-from grand_trade_auto.database import database_postgres
+from grand_trade_auto.database import postgres
 from grand_trade_auto.database import databases
 
 
@@ -28,7 +28,7 @@ def fixture_pg_test_db():
     Gets the test database handle for postgres.
 
     Returns:
-      (DatabasePostgres): The test postgres database handle.
+      (Postgres): The test postgres database handle.
     """
     return databases._get_database_from_config('test', 'postgres')
 
@@ -36,7 +36,7 @@ def fixture_pg_test_db():
 
 def test_load_from_config(pg_test_db):
     """
-    Tests the `load_from_config()` method in `DatabasePostgres`.
+    Tests the `load_from_config()` method in `Postgres`.
 
     TODO: This should load its own conf files and test directly; but good enough
     for now.
@@ -47,20 +47,18 @@ def test_load_from_config(pg_test_db):
 
 def test_get_type_names():
     """
-    Tests the `get_type_names()` method in `DatabasePostgres`.  Not an
-    exhaustive test.
+    Tests the `get_type_names()` method in `Postgres`.  Not an exhaustive test.
     """
-    assert 'postgres' in database_postgres.DatabasePostgres.get_type_names()
-    assert 'not-postgres' not in \
-            database_postgres.DatabasePostgres.get_type_names()
+    assert 'postgres' in postgres.Postgres.get_type_names()
+    assert 'not-postgres' not in postgres.Postgres.get_type_names()
 
 
 
 def test_connect(pg_test_db):
     """
-    Tests the `connect()` method in `DatabasePostgres`.  Only tests connecting
-    to the default database; connecting to the real test db will be covered by
-    another test.
+    Tests the `connect()` method in `Postgres`.  Only tests connecting to the
+    default database; connecting to the real test db will be covered by another
+    test.
     """
     conn = pg_test_db.connect(cache=False, database='postgres')
     assert conn is not None
@@ -78,8 +76,8 @@ def test_connect(pg_test_db):
 def test_create_drop_check_if_db_exists(pg_test_db):
     """
     Tests the `create_db()`, `_drop_db()`, and `_check_if_db_exists()` methods
-    in `DatabasePostgres`.  Done together since they are already intertwined and
-    test steps end up being very similar unless duplicating a bunch of code.
+    in `Postgres`.  Done together since they are already intertwined and test
+    steps end up being very similar unless duplicating a bunch of code.
     """
     # Want to ensure db does not exist before starting
     pg_test_db._drop_db()


### PR DESCRIPTION
Renames the following:
- `DatabaseMeta` -> `Database`
- `DatabasePostgres` -> `Postgres`
- `database_postgres` -> `postgres`
- `test_database_postgres` -> `test_postgres`

Also cleaned up any comments out of date, particularly around `Meta` name references still remaining.

Closes #80.