### PR TITLE
feature/85-db-conv-upd into develop

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -17,3 +17,7 @@ max-args=10
 disable=
         logging-fstring-interpolation,
         logging-not-lazy,
+
+
+[SIMILARITIES]
+min-similarity-lines=5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -131,6 +131,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Added] `logging-not-lazy` added to global disable list in `.pylintrc` to
      leave f-strings in logging to coder's choice ([#7][]).
 - [Added] `db` added to `good-names` list in `.pylintrc` ([#81][]).
+- [Added] `min-similarity-lines` config added, set to `5` ([#84][]).
 
 
 ### Project & Toolchain: Tmp Main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] `brokers.conf.ci` migrated to `apics.conf.ci` ([#75][]).
 - [Changed] Config file section IDs changed since an exact name must now match
       ([#81][]).
+- [Changed] Database `type` parameter is now `dbms` ([#84][]).
 
 
 ### Project & Toolchain: CodeCov
@@ -231,6 +232,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 ### Config: databases.conf
 - [Added] `databases.conf` file created (wtih stub), with postgres stub added
       ([#2][]).
+- [Changed] `type` parameter is now `dbms` ([#84][]).
 
 
 ### Config: gta.conf
@@ -263,7 +265,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] `_get_database_from_config()` changed to require `db_id`, thereby
       also changing the order of parameters ([#81][]).
 - [Changed] `__init__()` in `Database` now takes `**kwargs`, logs warning if
-      excess args leftover ([#85][]).
+      excess args leftover ([#84][]).
+- [Changed] `db_type` is now `dbms` ([#84][]).
 
 
 ### Database: Postgres
@@ -276,8 +279,9 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] Instance attributes and init parameters updated to match meta class,
       with some parameter init moved to meta class ([#81][]).
 - [Changed] `__init__()` updated now that parent supports `**kwargs` pass thru
-      ([#85][]).
-- [Changed] Last remnants of `db_handle` naming eradicated in code ([#85][]).
+      ([#84][]).
+- [Changed] Last remnants of `db_handle` naming eradicated in code ([#84][]).
+- [Changed] `db_type` is now `dbms` ([#84][]).
 
 
 ### Datafeeds / Meta
@@ -485,7 +489,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#77][]
 - [#80][]
 - [#81][]
-- [#85][]
+- [#84][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -517,6 +521,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#79][] for [#7][], [#54][]
 - [#83][] for [#80][]
 - [#85][] for [#81][]
+- [#86][] for [#84][]
 
 
 ---
@@ -555,7 +560,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#54]: https://github.com/JonathanCasey/grand_trade_auto/issues/54 'Issue #54'
 [#80]: https://github.com/JonathanCasey/grand_trade_auto/issues/80 'Issue #80'
 [#81]: https://github.com/JonathanCasey/grand_trade_auto/issues/81 'Issue #81'
-[#85]: https://github.com/JonathanCasey/grand_trade_auto/issues/85 'Issue #85'
+[#84]: https://github.com/JonathanCasey/grand_trade_auto/issues/84 'Issue #84'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -586,3 +591,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#79]: https://github.com/JonathanCasey/grand_trade_auto/pull/79 'PR #79'
 [#83]: https://github.com/JonathanCasey/grand_trade_auto/pull/83 'PR #83'
 [#85]: https://github.com/JonathanCasey/grand_trade_auto/pull/85 'PR #85'
+[#86]: https://github.com/JonathanCasey/grand_trade_auto/pull/86 'PR #86'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -262,6 +262,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       `Database`, loading from and storing to cache in the process ([#81][]).
 - [Changed] `_get_database_from_config()` changed to require `db_id`, thereby
       also changing the order of parameters ([#81][]).
+- [Changed] `__init__()` in `Database` now takes `**kwargs`, logs warning if
+      excess args leftover ([#85][]).
 
 
 ### Database: Postgres
@@ -273,6 +275,9 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] `DatabasePostgres` is now simply `Postgres` ([#80][]).
 - [Changed] Instance attributes and init parameters updated to match meta class,
       with some parameter init moved to meta class ([#81][]).
+- [Changed] `__init__()` updated now that parent supports `**kwargs` pass thru
+      ([#85][]).
+- [Changed] Last remnants of `db_handle` naming eradicated in code ([#85][]).
 
 
 ### Datafeeds / Meta
@@ -480,6 +485,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#77][]
 - [#80][]
 - [#81][]
+- [#85][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -549,6 +555,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#54]: https://github.com/JonathanCasey/grand_trade_auto/issues/54 'Issue #54'
 [#80]: https://github.com/JonathanCasey/grand_trade_auto/issues/80 'Issue #80'
 [#81]: https://github.com/JonathanCasey/grand_trade_auto/issues/81 'Issue #81'
+[#85]: https://github.com/JonathanCasey/grand_trade_auto/issues/85 'Issue #85'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'

--- a/ci_support/databases.conf.ci
+++ b/ci_support/databases.conf.ci
@@ -1,7 +1,7 @@
 
 [postgres-test]
 env : test
-type : postgres
+dbms : postgres
 host url : localhost
 port : 5432
 database : grand_trade_auto_TEST

--- a/config/stubs/databases.conf.default
+++ b/config/stubs/databases.conf.default
@@ -1,7 +1,7 @@
 
 [friendly-name-for-database]
 env : <production/development/test>
-type : <postgres>
+dbms : <postgres>
 host url :
 port :
 database : grand_trade_auto

--- a/grand_trade_auto/database/database_meta.py
+++ b/grand_trade_auto/database/database_meta.py
@@ -58,7 +58,7 @@ class Database(ABC):
 
 
 
-    def matches_id_criteria(self, db_id, env=None, db_type=None):
+    def matches_id_criteria(self, db_id, env=None, dbms=None):
         """
         Checks if this database is a match based on the provided criteria.
 
@@ -70,7 +70,7 @@ class Database(ABC):
           db_id (str): The section ID of the database from the databases.conf
             file to check if this matches.
           env (str or None): The environment for which to check if this matches.
-          db_type (str or None): The type to check if this matches.
+          dbms (str or None): The DBMS type to check if this matches.
 
 
         Returns:
@@ -85,7 +85,7 @@ class Database(ABC):
             return False
         if env is not None and env != self._env:
             return False
-        if db_type is not None and db_type not in self.get_type_names():
+        if dbms is not None and dbms not in self.get_dbms_names():
             return False
         return True
 
@@ -114,13 +114,14 @@ class Database(ABC):
 
     @classmethod
     @abstractmethod
-    def get_type_names(cls):
+    def get_dbms_names(cls):
         """
-        Get the list of names that can be used as the 'type' in the database
-        conf to identify this database.
+        Get the list of names that can be used as the 'dbms' in the database
+        conf to identify this database management system type.
 
         Returns:
-          ([str]): A list of names that are valid to use for this database type.
+          ([str]): A list of names that are valid to use for this DataBase
+            Management System.
         """
 
 

--- a/grand_trade_auto/database/database_meta.py
+++ b/grand_trade_auto/database/database_meta.py
@@ -10,6 +10,11 @@ Module Attributes:
 (C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 from abc import ABC, abstractmethod
+import logging
+
+
+
+logger = logging.getLogger(__name__)
 
 
 
@@ -19,21 +24,20 @@ class Database(ABC):
     will subclass this, but externally will likely only call the generic methods
     defined here to unify the interface.
 
+    This serves as a base class for other database systems, so will consume
+    any final kwargs.
+
     Class Attributes:
       N/A
 
     Instance Attributes:
-      env (str): The run environment type valid for using this database.
-      cp_db_id (str): The id used as the section name in the database conf.
+      _env (str): The run environment type valid for using this database.
+      _cp_db_id (str): The id used as the section name in the database conf.
         Will be used for loading credentials on-demand.
-      cp_secrets_id (str): The id used as the section name in the secrets
+      _cp_secrets_id (str): The id used as the section name in the secrets
         conf.  Will be used for loading credentials on-demand.
-      host (str): The host URL.
-      post (int): The port number on that host for accessing the database.
-      database (str): The database to open.
     """
-    def __init__(self, env, cp_db_id, cp_secrets_id,
-            host, port, database):             # pylint: disable=unused-argument
+    def __init__(self, env, cp_db_id, cp_secrets_id, **kwargs):
         """
         Creates the database handle.
 
@@ -43,13 +47,14 @@ class Database(ABC):
             Will be used for loading credentials on-demand.
           cp_secrets_id (str): The id used as the section name in the secrets
             conf.  Will be used for loading credentials on-demand.
-          host (str): The host URL.
-          post (int): The port number on that host for accessing the database.
-          database (str): The database to open.
         """
         self._env = env
         self._cp_db_id = cp_db_id
         self._cp_secrets_id = cp_secrets_id
+
+        if kwargs:
+            logger.warning('Discarded excess kwargs provided to'
+                    + f' {self.__class__.__name__}: {", ".join(kwargs.keys())}')
 
 
 
@@ -101,7 +106,7 @@ class Database(ABC):
             appears as the section header in the secrets_cp.
 
         Returns:
-          db_handle (Database<>): The Database<> object created and loaded from
+          db (Database<>): The Database<> object created and loaded from
             config, where Database<> is a subclass of Database (e.g. Postgres).
         """
 

--- a/grand_trade_auto/database/databases.py
+++ b/grand_trade_auto/database/databases.py
@@ -84,7 +84,7 @@ def _get_database_from_config(db_id, env=None):
 
     dbms_sel = None
     for dbms in _DBMSS:
-        if db_cp[db_id]['type'].strip() in dbms.get_type_names():
+        if db_cp[db_id]['dbms'].strip() in dbms.get_dbms_names():
             dbms_sel = dbms
             break
 

--- a/grand_trade_auto/database/postgres.py
+++ b/grand_trade_auto/database/postgres.py
@@ -30,36 +30,35 @@ class Postgres(database_meta.Database):
       N/A
 
     Instance Attributes:
-      _env (str): The run environment type valid for using this database.
-      _cp_db_id (str): The id used as the section name in the database conf.
-        Will be used for loading credentials on-demand.
-      _cp_secrets_id (str): The id used as the section name in the secrets
-        conf.  Will be used for loading credentials on-demand.
       _host (str): The host URL.
       _post (int): The port number on that host for accessing the database.
       _database (str): The database to open.
 
       _conn (connection): The cached database connection; or None if not
         connected and cached.
+
+      [inherited from Database]:
+        _env (str): The run environment type valid for using this database.
+        _cp_db_id (str): The id used as the section name in the database conf.
+          Will be used for loading credentials on-demand.
+        _cp_secrets_id (str): The id used as the section name in the secrets
+          conf.  Will be used for loading credentials on-demand.
     """
-    def __init__(self, env, host, port, database, cp_db_id, cp_secrets_id):
+    def __init__(self, host, port, database, **kwargs):
         """
         Creates the database handle.
 
         Args:
-          env (str): The run environment type valid for using this database.
-          cp_db_id (str): The id used as the section name in the database conf.
-            Will be used for loading credentials on-demand.
-          cp_secrets_id (str): The id used as the section name in the secrets
-            conf.  Will be used for loading credentials on-demand.
           host (str): The host URL.
           post (int): The port number on that host for accessing the database.
           database (str): The database to open.
+
+          See parent(s) for required kwargs.
         """
+        super().__init__(**kwargs)
         self._host = host
         self._port = port
         self._database = database
-        super().__init__(env, cp_db_id, cp_secrets_id, host, port, database)
 
         self._conn = None
 
@@ -79,8 +78,8 @@ class Postgres(database_meta.Database):
             appears as the section header in the secrets_cp.
 
         Returns:
-          db_handle (Postgres): The Postgres object created and loaded from
-            config based on the provided config data.
+          db (Postgres): The Postgres object created and loaded from config
+            based on the provided config data.
         """
         kwargs = {}
 
@@ -91,8 +90,8 @@ class Postgres(database_meta.Database):
         kwargs['database'] = db_cp[db_id]['database']
         kwargs['port'] = db_cp.getint(db_id, 'port', fallback=5432)
 
-        db_handle = Postgres(**kwargs)
-        return db_handle
+        db = Postgres(**kwargs)
+        return db
 
 
 

--- a/grand_trade_auto/database/postgres.py
+++ b/grand_trade_auto/database/postgres.py
@@ -96,13 +96,14 @@ class Postgres(database_meta.Database):
 
 
     @classmethod
-    def get_type_names(cls):
+    def get_dbms_names(cls):
         """
-        Get the list of names that can be used as the 'type' in the database
-        conf to identify this database.
+        Get the list of names that can be used as the 'dbms' in the database
+        conf to identify this database management system type.
 
         Returns:
-          ([str]): A list of names that are valid to use for this database type.
+          ([str]): A list of names that are valid to use for this DataBase
+            Management System.
         """
         return ['postgres', 'postgresql']
 

--- a/tests/unit/database/test_database_meta.py
+++ b/tests/unit/database/test_database_meta.py
@@ -38,7 +38,7 @@ def test_database_init(caplog):
             return
 
         @classmethod
-        def get_type_names(cls):
+        def get_dbms_names(cls):
             """
             Not needed / will not be used.
             """
@@ -102,11 +102,11 @@ def test_matches_id_criteria():
             return
 
         @classmethod
-        def get_type_names(cls):
+        def get_dbms_names(cls):
             """
             Need at least 1 name to match.
             """
-            return ['mock_type']
+            return ['mock_dbms']
 
         def create_db(self):
             """
@@ -119,10 +119,10 @@ def test_matches_id_criteria():
     assert db.matches_id_criteria('mock_cp_db_id')
     assert not db.matches_id_criteria('mock_cp_db_id', 'invalid-env')
     assert db.matches_id_criteria('mock_cp_db_id', 'mock_env')
-    assert not db.matches_id_criteria('mock_cp_db_id', db_type='invalid-type')
-    assert db.matches_id_criteria('mock_cp_db_id', db_type='mock_type')
+    assert not db.matches_id_criteria('mock_cp_db_id', dbms='invalid-dbms')
+    assert db.matches_id_criteria('mock_cp_db_id', dbms='mock_dbms')
     assert not db.matches_id_criteria('mock_cp_db_id', 'invalid-env',
-            'mock_type')
+            'mock_dbms')
     assert not db.matches_id_criteria('mock_cp_db_id', 'mock_env',
-            'invalid-type')
-    assert db.matches_id_criteria('mock_cp_db_id', 'mock_env', 'mock_type')
+            'invalid-dbms')
+    assert db.matches_id_criteria('mock_cp_db_id', 'mock_env', 'mock_dbms')

--- a/tests/unit/database/test_databases.py
+++ b/tests/unit/database/test_databases.py
@@ -65,13 +65,13 @@ def test_get_database_from_config(monkeypatch):
     assert databases._get_database_from_config('postgres-test', 'test') \
             is not None
 
-    def mock_get_type_names():
+    def mock_get_dbms_names():
         """
-        Replaces the `get_type_names()` in an database so it will find no match.
+        Replaces the `get_dbms_names()` in an database so it will find no match.
         """
         return []
 
-    monkeypatch.setattr(postgres.Postgres, 'get_type_names',
-            mock_get_type_names)
+    monkeypatch.setattr(postgres.Postgres, 'get_dbms_names',
+            mock_get_dbms_names)
 
     assert databases._get_database_from_config('postgres-test') is None

--- a/tests/unit/database/test_postgres.py
+++ b/tests/unit/database/test_postgres.py
@@ -45,12 +45,12 @@ def test_load_from_config(pg_test_db):
 
 
 
-def test_get_type_names():
+def test_get_dbms_names():
     """
-    Tests the `get_type_names()` method in `Postgres`.  Not an exhaustive test.
+    Tests the `get_dbms_names()` method in `Postgres`.  Not an exhaustive test.
     """
-    assert 'postgres' in postgres.Postgres.get_type_names()
-    assert 'not-postgres' not in postgres.Postgres.get_type_names()
+    assert 'postgres' in postgres.Postgres.get_dbms_names()
+    assert 'not-postgres' not in postgres.Postgres.get_dbms_names()
 
 
 


### PR DESCRIPTION
This cleans up some of the database to make it more inline with improvements to the API Client code.  These are primarily using an `__init__()` parameter structure that supports subclassing better by leveraging `**kwargs`; along with avoiding using the ambiguous (and protected keyword!) `type` in favor of `dbms`.

Closes #84.