### PR TITLE
feature/87-cache-secrets into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,9 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       loading from and storing to cache in the process ([#81][]).
 - [Changed] `_get_apic_from_config()` changed to require `apic_id`, thereby
       also changing the order of parameters ([#81][]).
+- [Removed] `_cp_secrets_id` no longer stored in `Apic`, and secrets no longer
+      loaded and passed in `_get_apic_from_config()` ([#82][]).
+- [Changed] `_cp_apic_id` is now `_apic_id` in `Apic` ([#82][]).
 
 
 ### APIC: Alpaca
@@ -178,6 +181,9 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       ([#75][]).
 - [Added] `Alpaca` now also inherits secondarily from `Datafeed` class ([#7][],
       [#54][]).
+- [Changed] Secrets passed in at `__init__()` and stored as `_key_id`,
+      `_secret_key`; loaded from conf at creation rather than on demand
+      ([#82][]).
 
 
 ### Brokers / Meta
@@ -268,6 +274,9 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] `__init__()` in `Database` now takes `**kwargs`, logs warning if
       excess args leftover ([#84][]).
 - [Changed] `db_type` is now `dbms` ([#84][]).
+- [Removed] `_cp_secrets_id` no longer stored in `Database`, and secrets no
+      longer loaded and passed in `_get_database_from_config()` ([#82][]).
+- [Changed] `_cp_db_id` is now `_db_id` in `Database` ([#82][]).
 
 
 ### Database: Postgres
@@ -283,6 +292,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       ([#84][]).
 - [Changed] Last remnants of `db_handle` naming eradicated in code ([#84][]).
 - [Changed] `db_type` is now `dbms` ([#84][]).
+- [Changed] Secrets passed in at `__init__()` and stored as `_user`,
+      `_password`; loaded from conf at creation rather than on demand ([#82][]).
 
 
 ### Datafeeds / Meta
@@ -490,6 +501,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#77][]
 - [#80][]
 - [#81][]
+- [#82][]
 - [#84][]
 
 #### PRs
@@ -523,6 +535,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#83][] for [#80][]
 - [#85][] for [#81][]
 - [#86][] for [#84][]
+- [#87][] for [#82][]
 
 
 ---
@@ -562,6 +575,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#80]: https://github.com/JonathanCasey/grand_trade_auto/issues/80 'Issue #80'
 [#81]: https://github.com/JonathanCasey/grand_trade_auto/issues/81 'Issue #81'
 [#84]: https://github.com/JonathanCasey/grand_trade_auto/issues/84 'Issue #84'
+[#82]: https://github.com/JonathanCasey/grand_trade_auto/issues/82 'Issue #82'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -593,3 +607,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#83]: https://github.com/JonathanCasey/grand_trade_auto/pull/83 'PR #83'
 [#85]: https://github.com/JonathanCasey/grand_trade_auto/pull/85 'PR #85'
 [#86]: https://github.com/JonathanCasey/grand_trade_auto/pull/86 'PR #86'
+[#87]: https://github.com/JonathanCasey/grand_trade_auto/pull/87 'PR #87'

--- a/grand_trade_auto/apic/apic_meta.py
+++ b/grand_trade_auto/apic/apic_meta.py
@@ -32,25 +32,18 @@ class Apic(ABC):
 
     Instance Attributes:
       _env (str): The run environment type valid for using this API Client.
-      _cp_apic_id (str): The id used as the section name in the API Client
-        conf.  Will be used for loading credentials on-demand.
-      _cp_secrets_id (str): The id used as the section name in the secrets
-        conf.  Will be used for loading credentials on-demand.
+      _apic_id (str): The id used as the section name in the API Client conf.
     """
-    def __init__(self, env, cp_apic_id, cp_secrets_id, **kwargs):
+    def __init__(self, env, apic_id, **kwargs):
         """
         Creates the API Client.
 
         Args:
           env (str): The run environment type valid for using this API Client.
-          cp_apic_id (str): The id used as the section name in the API Client
-            conf.  Will be used for loading credentials on-demand.
-          cp_secrets_id (str): The id used as the section name in the secrets
-            conf.  Will be used for loading credentials on-demand.
+          apic_id (str): The id used as the section name in the API Client conf.
         """
         self._env = env
-        self._cp_apic_id = cp_apic_id
-        self._cp_secrets_id = cp_secrets_id
+        self._apic_id = apic_id
 
         if kwargs:
             logger.warning('Discarded excess kwargs provided to'
@@ -81,7 +74,7 @@ class Apic(ABC):
             criteria provided cannot guarantee a minimum level of definition.
         """
         assert apic_id is not None
-        if apic_id != self._cp_apic_id:
+        if apic_id != self._apic_id:
             return False
         if env is not None and env != self._env:
             return False
@@ -93,7 +86,7 @@ class Apic(ABC):
 
     @classmethod
     @abstractmethod
-    def load_from_config(cls, apic_cp, apic_id, secrets_id):
+    def load_from_config(cls, apic_cp, apic_id):
         """
         Loads the API Client config for this API Client from the configparsers
         from files provided.
@@ -103,8 +96,6 @@ class Apic(ABC):
             conf.
           apic_id (str): The ID name for this API Client as it appears as the
             section header in the apic_cp.
-          secrets_id (str): The ID name for this API Client's secrets as it
-            appears as the section header in the secrets_cp.
 
         Returns:
           apic (Apic<>): The Apic<> object created and loaded from config, where

--- a/grand_trade_auto/apic/apics.py
+++ b/grand_trade_auto/apic/apics.py
@@ -75,7 +75,6 @@ def _get_apic_from_config(apic_id, env=None):
     assert apic_id is not None
 
     apic_cp = config.read_conf_file('apics.conf')
-    secrets_cp = config.read_conf_file('.secrets.conf')
 
     if apic_id not in apic_cp.sections():
         return None
@@ -93,6 +92,5 @@ def _get_apic_from_config(apic_id, env=None):
     if apic_provider_sel is None:
         return None
 
-    secrets_id = config.get_matching_secrets_id(secrets_cp, 'apic', apic_id)
-    apic = apic_provider_sel.load_from_config(apic_cp, apic_id, secrets_id)
+    apic = apic_provider_sel.load_from_config(apic_cp, apic_id)
     return apic

--- a/grand_trade_auto/database/database_meta.py
+++ b/grand_trade_auto/database/database_meta.py
@@ -32,25 +32,18 @@ class Database(ABC):
 
     Instance Attributes:
       _env (str): The run environment type valid for using this database.
-      _cp_db_id (str): The id used as the section name in the database conf.
-        Will be used for loading credentials on-demand.
-      _cp_secrets_id (str): The id used as the section name in the secrets
-        conf.  Will be used for loading credentials on-demand.
+      _db_id (str): The id used as the section name in the database conf.
     """
-    def __init__(self, env, cp_db_id, cp_secrets_id, **kwargs):
+    def __init__(self, env, db_id, **kwargs):
         """
         Creates the database handle.
 
         Args:
           env (str): The run environment type valid for using this database.
-          cp_db_id (str): The id used as the section name in the database conf.
-            Will be used for loading credentials on-demand.
-          cp_secrets_id (str): The id used as the section name in the secrets
-            conf.  Will be used for loading credentials on-demand.
+          db_id (str): The id used as the section name in the database conf.
         """
         self._env = env
-        self._cp_db_id = cp_db_id
-        self._cp_secrets_id = cp_secrets_id
+        self._db_id = db_id
 
         if kwargs:
             logger.warning('Discarded excess kwargs provided to'
@@ -81,7 +74,7 @@ class Database(ABC):
             criteria provided cannot guarantee a minimum level of definition.
         """
         assert db_id is not None
-        if db_id != self._cp_db_id:
+        if db_id != self._db_id:
             return False
         if env is not None and env != self._env:
             return False
@@ -93,7 +86,7 @@ class Database(ABC):
 
     @classmethod
     @abstractmethod
-    def load_from_config(cls, db_cp, db_id, secrets_id):
+    def load_from_config(cls, db_cp, db_id):
         """
         Loads the database config for this database from the configparsers
         from files provided.
@@ -102,8 +95,6 @@ class Database(ABC):
           db_cp (configparser): The full configparser from the database conf.
           db_id (str): The ID name for this database as it appears as the
             section header in the db_cp.
-          secrets_id (str): The ID name for this database's secrets as it
-            appears as the section header in the secrets_cp.
 
         Returns:
           db (Database<>): The Database<> object created and loaded from

--- a/grand_trade_auto/database/databases.py
+++ b/grand_trade_auto/database/databases.py
@@ -74,7 +74,6 @@ def _get_database_from_config(db_id, env=None):
     assert db_id is not None
 
     db_cp = config.read_conf_file('databases.conf')
-    secrets_cp = config.read_conf_file('.secrets.conf')
 
     if db_id not in db_cp.sections():
         return None
@@ -91,6 +90,5 @@ def _get_database_from_config(db_id, env=None):
     if dbms_sel is None:
         return None
 
-    secrets_id = config.get_matching_secrets_id(secrets_cp, 'database', db_id)
-    db = dbms_sel.load_from_config(db_cp, db_id, secrets_id)
+    db = dbms_sel.load_from_config(db_cp, db_id)
     return db

--- a/tests/unit/apic/test_apic_meta.py
+++ b/tests/unit/apic/test_apic_meta.py
@@ -31,7 +31,7 @@ def test_apic_init(caplog):
         """
 
         @classmethod
-        def load_from_config(cls, apic_cp, apic_id, secrets_id):
+        def load_from_config(cls, apic_cp, apic_id):
             """
             Not needed / will not be used.
             """
@@ -52,7 +52,7 @@ def test_apic_init(caplog):
 
     caplog.set_level(logging.WARNING)
     caplog.clear()
-    MockApicChild('mock_env', 'mock_cp_apic_id', 'mock_cp_secrets_id')
+    MockApicChild('mock_env', 'mock_apic_id')
     assert caplog.record_tuples == []
 
     extra_kwargs = {
@@ -60,8 +60,7 @@ def test_apic_init(caplog):
             'key2': 'val2',
     }
     caplog.clear()
-    MockApicChild('mock_env', 'mock_cp_apic_id', 'mock_cp_secrets_id',
-            **extra_kwargs)
+    MockApicChild('mock_env', 'mock_apic_id', **extra_kwargs)
     assert caplog.record_tuples == [
             ('grand_trade_auto.apic.apic_meta', logging.WARNING,
                 'Discarded excess kwargs provided to MockApicChild: key1, key2')
@@ -70,12 +69,11 @@ def test_apic_init(caplog):
     # Using Alpaca to test grandchild with multiple/diamond inheritance pattern
     kwargs = {
         'env': 'mock_env',
-        'cp_apic_id': 'mock_cp_apic_id',
-        'cp_secrets_id': 'mock_cp_secrets_id',
+        'apic_id': 'mock_apic_id',
         **extra_kwargs,
     }
     caplog.clear()
-    alpaca.Alpaca('paper', **kwargs)
+    alpaca.Alpaca('paper', 'mock_key_id', 'mock_secret_key', **kwargs)
     assert caplog.record_tuples == [
             ('grand_trade_auto.apic.apic_meta', logging.WARNING,
                 'Discarded excess kwargs provided to Alpaca: key1, key2')
@@ -94,7 +92,7 @@ def test_matches_id_criteria():
         """
 
         @classmethod
-        def load_from_config(cls, apic_cp, apic_id, secrets_id):
+        def load_from_config(cls, apic_cp, apic_id):
             """
             Not needed / will not be used.
             """
@@ -113,18 +111,17 @@ def test_matches_id_criteria():
             """
             return
 
-    apic = MockApicChild('mock_env', 'mock_cp_apic_id', 'mock_cp_secrets_id')
+    apic = MockApicChild('mock_env', 'mock_apic_id')
     assert not apic.matches_id_criteria('invalid-apic-id')
-    assert apic.matches_id_criteria('mock_cp_apic_id')
-    assert not apic.matches_id_criteria('mock_cp_apic_id', 'invalid-env')
-    assert apic.matches_id_criteria('mock_cp_apic_id', 'mock_env')
-    assert not apic.matches_id_criteria('mock_cp_apic_id',
+    assert apic.matches_id_criteria('mock_apic_id')
+    assert not apic.matches_id_criteria('mock_apic_id', 'invalid-env')
+    assert apic.matches_id_criteria('mock_apic_id', 'mock_env')
+    assert not apic.matches_id_criteria('mock_apic_id',
             provider='invalid-provider')
-    assert apic.matches_id_criteria('mock_cp_apic_id',
-            provider='mock_provider')
-    assert not apic.matches_id_criteria('mock_cp_apic_id', 'invalid-env',
+    assert apic.matches_id_criteria('mock_apic_id', provider='mock_provider')
+    assert not apic.matches_id_criteria('mock_apic_id', 'invalid-env',
             'mock_provider')
-    assert not apic.matches_id_criteria('mock_cp_apic_id', 'mock_env',
+    assert not apic.matches_id_criteria('mock_apic_id', 'mock_env',
             'invalid-provider')
-    assert apic.matches_id_criteria('mock_cp_apic_id', 'mock_env',
+    assert apic.matches_id_criteria('mock_apic_id', 'mock_env',
             'mock_provider')

--- a/tests/unit/database/test_database_meta.py
+++ b/tests/unit/database/test_database_meta.py
@@ -31,7 +31,7 @@ def test_database_init(caplog):
         """
 
         @classmethod
-        def load_from_config(cls, db_cp, db_id, secrets_id):
+        def load_from_config(cls, db_cp, db_id):
             """
             Not needed / will not be used.
             """
@@ -52,7 +52,7 @@ def test_database_init(caplog):
 
     caplog.set_level(logging.WARNING)
     caplog.clear()
-    MockDatabaseChild('mock_env', 'mock_cp_db_id', 'mock_cp_secrets_id')
+    MockDatabaseChild('mock_env', 'mock_db_id')
     assert caplog.record_tuples == []
 
     extra_kwargs = {
@@ -60,8 +60,7 @@ def test_database_init(caplog):
             'key2': 'val2',
     }
     caplog.clear()
-    MockDatabaseChild('mock_env', 'mock_cp_db_id', 'mock_cp_secrets_id',
-            **extra_kwargs)
+    MockDatabaseChild('mock_env', 'mock_db_id', **extra_kwargs)
     assert caplog.record_tuples == [
             ('grand_trade_auto.database.database_meta', logging.WARNING,
                 'Discarded excess kwargs provided to MockDatabaseChild:'
@@ -71,12 +70,12 @@ def test_database_init(caplog):
     # Using Postgres to test inheritance consumption
     kwargs = {
         'env': 'mock_env',
-        'cp_db_id': 'mock_cp_db_id',
-        'cp_secrets_id': 'mock_cp_secrets_id',
+        'db_id': 'mock_db_id',
         **extra_kwargs,
     }
     caplog.clear()
-    postgres.Postgres('mock_host', -1, 'mock_database', **kwargs)
+    postgres.Postgres('mock_host', -1, 'mock_database', 'mock_user',
+            'mock_password', **kwargs)
     assert caplog.record_tuples == [
             ('grand_trade_auto.database.database_meta', logging.WARNING,
                 'Discarded excess kwargs provided to Postgres: key1, key2')
@@ -95,7 +94,7 @@ def test_matches_id_criteria():
         """
 
         @classmethod
-        def load_from_config(cls, db_cp, db_id, secrets_id):
+        def load_from_config(cls, db_cp, db_id):
             """
             Not needed / will not be used.
             """
@@ -114,15 +113,13 @@ def test_matches_id_criteria():
             """
             return
 
-    db = MockDatabaseChild('mock_env', 'mock_cp_db_id', 'mock_cp_secrets_id')
+    db = MockDatabaseChild('mock_env', 'mock_db_id')
     assert not db.matches_id_criteria('invalid-db-id')
-    assert db.matches_id_criteria('mock_cp_db_id')
-    assert not db.matches_id_criteria('mock_cp_db_id', 'invalid-env')
-    assert db.matches_id_criteria('mock_cp_db_id', 'mock_env')
-    assert not db.matches_id_criteria('mock_cp_db_id', dbms='invalid-dbms')
-    assert db.matches_id_criteria('mock_cp_db_id', dbms='mock_dbms')
-    assert not db.matches_id_criteria('mock_cp_db_id', 'invalid-env',
-            'mock_dbms')
-    assert not db.matches_id_criteria('mock_cp_db_id', 'mock_env',
-            'invalid-dbms')
-    assert db.matches_id_criteria('mock_cp_db_id', 'mock_env', 'mock_dbms')
+    assert db.matches_id_criteria('mock_db_id')
+    assert not db.matches_id_criteria('mock_db_id', 'invalid-env')
+    assert db.matches_id_criteria('mock_db_id', 'mock_env')
+    assert not db.matches_id_criteria('mock_db_id', dbms='invalid-dbms')
+    assert db.matches_id_criteria('mock_db_id', dbms='mock_dbms')
+    assert not db.matches_id_criteria('mock_db_id', 'invalid-env', 'mock_dbms')
+    assert not db.matches_id_criteria('mock_db_id', 'mock_env', 'invalid-dbms')
+    assert db.matches_id_criteria('mock_db_id', 'mock_env', 'mock_dbms')


### PR DESCRIPTION
This removes the load-on-demand approach to handling secrets and instead stores them in their relevant objects to make it easier to use.

Closes #82.