### PR TITLE
feature/88-add-alphavantage into develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ workflows:
           context:
             - docker-hub-creds
             - alpaca-paper-creds
+            - alphavantage-creds
   changelog-updated:
     jobs:
       - diff-changelog-last-commit:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -163,6 +163,8 @@ jobs:
             echo '\n[apics :: alpaca-test]\n' >> config/.secrets.conf
             echo 'api key id : $APCA_API_KEY_ID\n'  >> config/.secrets.conf
             echo 'secret key : $APCA_API_SECRET_KEY\n' >> config/.secrets.conf
+            echo '\n[apics :: alphavantage-test]\n' >> config/.secrets.conf
+            echo 'api key : $ALPHAVANTAGE_API_KEY\n'  >> config/.secrets.conf
       - run:
           name: Run pytest unit tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,11 +161,11 @@ jobs:
             mv ci_support/databases.conf.ci config/databases.conf
             mv ci_support/.secrets.conf.ci config/.secrets.conf
             mv ci_support/apics.conf.ci config/apics.conf
-            echo '\n[apics :: alpaca-test]\n' >> config/.secrets.conf
-            echo 'api key id : $APCA_API_KEY_ID\n'  >> config/.secrets.conf
-            echo 'secret key : $APCA_API_SECRET_KEY\n' >> config/.secrets.conf
-            echo '\n[apics :: alphavantage-test]\n' >> config/.secrets.conf
-            echo 'api key : $ALPHAVANTAGE_API_KEY\n'  >> config/.secrets.conf
+            echo -e '\n[apics :: alpaca-test]\n' >> config/.secrets.conf
+            echo -e 'api key id : $APCA_API_KEY_ID\n'  >> config/.secrets.conf
+            echo -e 'secret key : $APCA_API_SECRET_KEY\n' >> config/.secrets.conf
+            echo -e '\n[apics :: alphavantage-test]\n' >> config/.secrets.conf
+            echo -e 'api key : $ALPHAVANTAGE_API_KEY\n'  >> config/.secrets.conf
       - run:
           name: Run pytest unit tests
           command: |

--- a/.pylintrc
+++ b/.pylintrc
@@ -20,4 +20,4 @@ disable=
 
 
 [SIMILARITIES]
-min-similarity-lines=5
+min-similarity-lines=8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       `brokers` ([#75][]).
 - [Changed] Config file section IDs changed since an exact name must now match
       ([#81][]).
+- [Added] Alpha Vantage context added for those creds, as well as export to
+      secrets ([#88][]).
+- [Fixed] Secrets export from environment variables weren't really working due
+      to how `\n` was being interpreted ([#88][]).
 
 
 ### Project & Toolchain: CI Support
@@ -90,6 +94,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] Config file section IDs changed since an exact name must now match
       ([#81][]).
 - [Changed] Database `type` parameter is now `dbms` ([#84][]).
+- [Added] Alpha Vantage support added to conf files for CI ([#88][]).
 
 
 ### Project & Toolchain: CodeCov
@@ -118,6 +123,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       ([#6][]).
 - [Added] `aiofiles`, `beautifulsoup4`, `fastapi`, `jinja2`, and `uvicorn` added
       to `requirements.txt` ([#11][]).
+- [Added] `alpha_vantage` added to `requirements.txt` ([#88][]).
 
 
 ### Project & Toolchain: Pylint
@@ -132,6 +138,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
      leave f-strings in logging to coder's choice ([#7][]).
 - [Added] `db` added to `good-names` list in `.pylintrc` ([#81][]).
 - [Added] `min-similarity-lines` config added, set to `5` ([#84][]).
+- [Changed] `min-similarity-lines` increased to `8` ([#88][]).
 
 
 ### Project & Toolchain: Tmp Main
@@ -171,6 +178,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Removed] `_cp_secrets_id` no longer stored in `Apic`, and secrets no longer
       loaded and passed in `_get_apic_from_config()` ([#82][]).
 - [Changed] `_cp_apic_id` is now `_apic_id` in `Apic` ([#82][]).
+- [Added] `Alphavantage` added to list of `_APIC_PROVIDERS` ([#88][]).
 
 
 ### APIC: Alpaca
@@ -184,6 +192,11 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Changed] Secrets passed in at `__init__()` and stored as `_key_id`,
       `_secret_key`; loaded from conf at creation rather than on demand
       ([#82][]).
+
+
+### APIC: Alphavantage
+- [Added] `Alphavantage` file and class started, with ability to load from
+      config and ready to make API calls ([#88][]).
 
 
 ### Brokers / Meta
@@ -212,6 +225,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       stub added ([#2][]).
 - [Added] Broker example stub added, at least as would be needed for Alpaca
       ([#6][]).
+- [Added] Alpha Vantage support added, clarified which example is for which API
+      Client ([#88][]).
 
 
 ### Config: .secrets.env
@@ -225,6 +240,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       supported ([#75][]).
 - [Changed] `type` key changed to `provider` to avoid confusion from generic
       sounding `type` ([#75][]).
+- [Added] Alpha Vantage support added ([#88][]).
 
 
 ### Config: brokers.conf (see Config: apics.conf)
@@ -432,6 +448,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       `setup.md` and `usage.md` migrated ([#62][]).
 - [Added] Added section for "config files and unit testing", listing required
       section IDs ([#81][]).
+- [Added] Alpha Vantage added, including conf section requirement, along with
+      warning that API calls may be consumed in unit tests ([#88][]).
 
 
 ### Docs: README
@@ -503,6 +521,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#81][]
 - [#82][]
 - [#84][]
+- [#88][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -536,6 +555,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#85][] for [#81][]
 - [#86][] for [#84][]
 - [#87][] for [#82][]
+- [#90][] for [#88][]
 
 
 ---
@@ -576,6 +596,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#81]: https://github.com/JonathanCasey/grand_trade_auto/issues/81 'Issue #81'
 [#84]: https://github.com/JonathanCasey/grand_trade_auto/issues/84 'Issue #84'
 [#82]: https://github.com/JonathanCasey/grand_trade_auto/issues/82 'Issue #82'
+[#88]: https://github.com/JonathanCasey/grand_trade_auto/issues/88 'Issue #88'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -608,3 +629,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#85]: https://github.com/JonathanCasey/grand_trade_auto/pull/85 'PR #85'
 [#86]: https://github.com/JonathanCasey/grand_trade_auto/pull/86 'PR #86'
 [#87]: https://github.com/JonathanCasey/grand_trade_auto/pull/87 'PR #87'
+[#90]: https://github.com/JonathanCasey/grand_trade_auto/pull/90 'PR #90'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,10 +64,14 @@ are required in their respective config files in order to run the relevant
 unit tests:
 - `apics.conf`:
   - `alpaca-test`
+  - `alphavantage-test`
 - `databases.conf`
   - `postgres-test` (do NOT use production db.  WILL be DELETED!)
 
 The `env` for each of those must be `test`.
+
+Note that some test WILL make API calls, so it will count against any rate
+limiting or quotas.
 
 
 

--- a/ci_support/apics.conf.ci
+++ b/ci_support/apics.conf.ci
@@ -3,3 +3,9 @@
 env : test
 provider : alpaca
 trade domain : paper
+
+
+
+[alphavantage-test]
+env : test
+provider : alphavantage

--- a/config/stubs/.secrets.conf.default
+++ b/config/stubs/.secrets.conf.default
@@ -1,9 +1,16 @@
 
 [apic :: friendly-name-for-api-client]
+# Alpaca
 # Can define/override `api key id` here if desired
 secret key :
 
 
+[apic :: friendly-name-for-api-client]
+# Alpha Vantage
+api key :
+
+
 [database :: friendly-name-for-database]
+# Postgres
 # Can define/override `username` here if desired
 password :

--- a/config/stubs/apics.conf.default
+++ b/config/stubs/apics.conf.default
@@ -4,3 +4,8 @@ env : <production/development/test>
 provider : <alpaca>
 trade domain : <live/paper>
 api key id :
+
+
+[friendly-name-for-api-client]
+env : <production/development/test>
+provider : <alphavantage>

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -16,6 +16,10 @@ provided as environment variables instead as `APCA_API_KEY_ID` and
 `APCA_API_SECRET_KEY`, respectively, as documented in the
 [alpaca-trade-api-python](https://github.com/alpacahq/alpaca-trade-api-python/).
 
+For alphavantage, the API key can similarly be provided as an environment
+variable `ALPHAVANTAGE_API_KEY` as documented in
+[RomelTorres' alpha_vantage](https://github.com/RomelTorres/alpha_vantage).
+
 **DATA LOSS WARNING**: If planning to run unit tests, a test env database config
 will need to be provided.  This MUST be different from the database used for
 production and development, as it will create, add/modify data, and then drop

--- a/grand_trade_auto/apic/__init__.py
+++ b/grand_trade_auto/apic/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
         'alpaca',
+        'alphavantage',
         'apic_meta',
         'apics',
 ]

--- a/grand_trade_auto/apic/alphavantage.py
+++ b/grand_trade_auto/apic/alphavantage.py
@@ -8,13 +8,12 @@ Module Attributes:
 
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
-from grand_trade_auto.broker import broker_meta
 from grand_trade_auto.datafeed import datafeed_meta
 from grand_trade_auto.general import config
 
 
 
-class Alphavantage(broker_meta.Broker, datafeed_meta.Datafeed):
+class Alphavantage(datafeed_meta.Datafeed):
     """
     The Alpha Vantage broker API Client functionality.
 

--- a/grand_trade_auto/apic/alphavantage.py
+++ b/grand_trade_auto/apic/alphavantage.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""
+Alpha Vantage functionality to implement the generic interface components
+defined by the metaclass.
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+from grand_trade_auto.broker import broker_meta
+from grand_trade_auto.datafeed import datafeed_meta
+from grand_trade_auto.general import config
+
+
+
+class Alphavantage(broker_meta.Broker, datafeed_meta.Datafeed):
+    """
+    The Alpha Vantage broker API Client functionality.
+
+    Class Attributes:
+      N/A
+
+    Instance Attributes:
+      _api_key (str): The API key used for authentication.
+
+      [inherited from Apic]:
+        _env (str): The run environment type valid for using this API Client.
+        _apic_id (str): The id used as the section name in the API Client conf.
+    """
+    def __init__(self, api_key, **kwargs):
+        """
+        Creates the Alpha Vantage API client.
+
+        Args:
+          api_key (str): The secret key used for authentication.
+
+          See parent(s) for required kwargs.
+        """
+        super().__init__(**kwargs)
+        self._api_key = api_key
+
+
+
+    @classmethod
+    def load_from_config(cls, apic_cp, apic_id):
+        """
+        Loads the Alpha Vantage config from the configparsers from files
+        provided.
+
+        Args:
+          apic_cp (configparser): The full configparser from the API Client
+            conf.
+          apic_id (str): The ID name for this API Client as it appears as the
+            section header in the apic_cp.
+
+        Returns:
+          alphav (Alphavantage): The Alpha Vantage object created and loaded
+            from config.
+        """
+        apic_cp = config.read_conf_file('apics.conf')
+        secrets_cp = config.read_conf_file('.secrets.conf')
+        secrets_id = config.get_matching_secrets_id(secrets_cp, 'apic', apic_id)
+
+        kwargs = {}
+        kwargs['env'] = apic_cp[apic_id]['env'].strip()
+        kwargs['apic_id'] = apic_id
+
+        kwargs['api_key'] = secrets_cp.get(secrets_id, 'api key', fallback=None)
+
+        alphav = Alphavantage(**kwargs)
+        return alphav
+
+
+
+    @classmethod
+    def get_provider_names(cls):
+        """
+        Get the list of names that can be used as the 'provider' in the API
+        Client conf to identify this API Client.
+
+        Returns:
+          ([str]): A list of names that are valid to use for this API Client
+            provider.
+        """
+        return ['alpha vantage', 'alphavantage', 'alphav', 'av']
+
+
+
+    def connect(self):
+        """
+        Connects to the API provider's servers.
+        """
+        # No connection to maintain
+        return

--- a/grand_trade_auto/apic/apics.py
+++ b/grand_trade_auto/apic/apics.py
@@ -11,12 +11,14 @@ Module Attributes:
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 from grand_trade_auto.apic import alpaca
+from grand_trade_auto.apic import alphavantage
 from grand_trade_auto.general import config
 
 
 
 _APIC_PROVIDERS = (
     alpaca.Alpaca,
+    alphavantage.Alphavantage,
 )
 
 _apics_loaded = {}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 aiofiles
 alpaca-trade-api==0.51.0
+alpha_vantage==2.3.1
 beautifulsoup4
 fastapi
 jinja2

--- a/tests/unit/apic/__init__.py
+++ b/tests/unit/apic/__init__.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
         'test_alpaca',
+        'test_alphavantage',
         'test_apic_meta',
         'test_apics',
 ]

--- a/tests/unit/apic/test_alphavantage.py
+++ b/tests/unit/apic/test_alphavantage.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Tests the grand_trade_auto.apic.alphavantage functionality.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  N/A
+
+(C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
+import logging
+import os
+
+from alpha_vantage.timeseries import TimeSeries
+import pytest
+
+from grand_trade_auto.apic import alphavantage
+from grand_trade_auto.apic import apics
+
+
+
+@pytest.fixture(name='alphavantage_test')
+def fixture_alphavantage_test():
+    """
+    Gets the test API Client handle for Alpha Vantage.
+
+    Returns:
+      (Alphavantage): The test Alpha Vantage API Client handle.
+    """
+    # This also ensures its support was added to apics.py
+    return apics._get_apic_from_config('alphavantage-test', 'test')
+
+
+
+def test_load_from_config(alphavantage_test):
+    """
+    Tests the `load_from_config()` method in `Alphavantage`.
+
+    TODO: This should load its own conf files and test directly; but good enough
+    for now.
+    """
+    assert alphavantage_test is not None
+
+
+
+def test_get_provider_names():
+    """
+    Tests the `get_provider_names()` method in `Alpaca`.  Not an exhaustive
+    test.
+    """
+    assert 'alphavantage' in alphavantage.Alphavantage.get_provider_names()
+    assert 'not-alphavantage' \
+            not in alphavantage.Alphavantage.get_provider_names()


### PR DESCRIPTION
This adds support for Alpha Vantage as a datafeed source.  Very bare bones proof-of-concept sort of code, but it gets this started.

Closes #88.