### PR TITLE
feature/93-circleci-codecov-fixes into develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,10 +162,10 @@ jobs:
             mv ci_support/.secrets.conf.ci config/.secrets.conf
             mv ci_support/apics.conf.ci config/apics.conf
             echo -e '\n[apics :: alpaca-test]\n' >> config/.secrets.conf
-            echo -e 'api key id : $APCA_API_KEY_ID\n'  >> config/.secrets.conf
-            echo -e 'secret key : $APCA_API_SECRET_KEY\n' >> config/.secrets.conf
+            echo -e 'api key id : '$APCA_API_KEY_ID'\n'  >> config/.secrets.conf
+            echo -e 'secret key : '$APCA_API_SECRET_KEY'\n' >> config/.secrets.conf
             echo -e '\n[apics :: alphavantage-test]\n' >> config/.secrets.conf
-            echo -e 'api key : $ALPHAVANTAGE_API_KEY\n'  >> config/.secrets.conf
+            echo -e 'api key : '$ALPHAVANTAGE_API_KEY'\n'  >> config/.secrets.conf
       - run:
           name: Run pytest unit tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,9 @@ jobs:
           name: Upload coverage results
           command: |
             . venv/bin/activate
-            bash <(curl -s https://codecov.io/bash)
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            chmod +x codecov
+            ./codecov
   diff-changelog-last-commit:
     <<: *default_git_image
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 
 workflows:
-  lint-and-test:
+  lint:
     jobs:
       - pylint-app:
           context:
@@ -16,6 +16,8 @@ workflows:
       - init-py-checker:
           context:
             - docker-hub-creds
+  test:
+    jobs:
       - unit-tests:
           context:
             - docker-hub-creds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       uploader ([#93][]).
 - [Fixed] Secrets export from environment variables still not working as
       intended, so syntax adjusted again ([#93][]).
+- [Changed] `lint-and-test` workflow split into separate `lint` and `test`
+      workflows to more easily see results separately on GitHub ([#93][]).
 
 
 ### Project & Toolchain: CI Support

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       secrets ([#88][]).
 - [Fixed] Secrets export from environment variables weren't really working due
       to how `\n` was being interpreted ([#88][]).
+- [Changed] Codecov uploader migrated from deprecated bash uploader to new
+      uploader ([#93][]).
 
 
 ### Project & Toolchain: CI Support
@@ -525,6 +527,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#84][]
 - [#88][]
 - [#91][]
+- [#93][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -602,6 +605,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#82]: https://github.com/JonathanCasey/grand_trade_auto/issues/82 'Issue #82'
 [#88]: https://github.com/JonathanCasey/grand_trade_auto/issues/88 'Issue #88'
 [#91]: https://github.com/JonathanCasey/grand_trade_auto/issues/91 'Issue #91'
+[#93]: https://github.com/JonathanCasey/grand_trade_auto/issues/93 'Issue #93'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       to how `\n` was being interpreted ([#88][]).
 - [Changed] Codecov uploader migrated from deprecated bash uploader to new
       uploader ([#93][]).
+- [Fixed] Secrets export from environment variables still not working as
+      intended, so syntax adjusted again ([#93][]).
 
 
 ### Project & Toolchain: CI Support
@@ -563,6 +565,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#87][] for [#82][]
 - [#90][] for [#88][]
 - [#92][] for [#91][]
+- [#94][] for [#93][]
 
 
 ---
@@ -640,3 +643,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#87]: https://github.com/JonathanCasey/grand_trade_auto/pull/87 'PR #87'
 [#90]: https://github.com/JonathanCasey/grand_trade_auto/pull/90 'PR #90'
 [#92]: https://github.com/JonathanCasey/grand_trade_auto/pull/92 'PR #92'
+[#94]: https://github.com/JonathanCasey/grand_trade_auto/pull/94 'PR #94'


### PR DESCRIPTION
This migrates CodeCov in the CircleCI script to use a new uploader instead of the deprecated bash uploader.

This also fixes minor issues in writing the secrets file by using `echo` in combination with env vars.

Finally, this also split lint and test into separate CI workflows to more easily see which one failed, if any.  This does NOT make test contingent on lint passing since it is rare that line failures are causing major test issues.

Closes #93.