### PR TITLE
feature/95-96-alpaca-pylint-fixes into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Added] `db` added to `good-names` list in `.pylintrc` ([#81][]).
 - [Added] `min-similarity-lines` config added, set to `5` ([#84][]).
 - [Changed] `min-similarity-lines` increased to `8` ([#88][]).
+- [Fixed] Code made compliant with latest version of pylint (v2.12) ([#96][]).
 
 
 ### Project & Toolchain: Tmp Main
@@ -535,6 +536,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#91][]
 - [#93][]
 - [#95][]
+- [#96][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -571,6 +573,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#90][] for [#88][]
 - [#92][] for [#91][]
 - [#94][] for [#93][]
+- [#97][] for [#95][], [#96][]
 
 
 ---
@@ -615,6 +618,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#91]: https://github.com/JonathanCasey/grand_trade_auto/issues/91 'Issue #91'
 [#93]: https://github.com/JonathanCasey/grand_trade_auto/issues/93 'Issue #93'
 [#95]: https://github.com/JonathanCasey/grand_trade_auto/issues/95 'Issue #95'
+[#96]: https://github.com/JonathanCasey/grand_trade_auto/issues/96 'Issue #96'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -650,3 +654,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#90]: https://github.com/JonathanCasey/grand_trade_auto/pull/90 'PR #90'
 [#92]: https://github.com/JonathanCasey/grand_trade_auto/pull/92 'PR #92'
 [#94]: https://github.com/JonathanCasey/grand_trade_auto/pull/94 'PR #94'
+[#97]: https://github.com/JonathanCasey/grand_trade_auto/pull/97 'PR #97'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Added] `aiofiles`, `beautifulsoup4`, `fastapi`, `jinja2`, and `uvicorn` added
       to `requirements.txt` ([#11][]).
 - [Added] `alpha_vantage` added to `requirements.txt` ([#88][]).
+- [Changed] `alpaca-trade-api` fixed version upgraded from `0.51.0` to `1.4.3`
+      ([#95][]).
 
 
 ### Project & Toolchain: Pylint
@@ -532,6 +534,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#88][]
 - [#91][]
 - [#93][]
+- [#95][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -611,6 +614,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#88]: https://github.com/JonathanCasey/grand_trade_auto/issues/88 'Issue #88'
 [#91]: https://github.com/JonathanCasey/grand_trade_auto/issues/91 'Issue #91'
 [#93]: https://github.com/JonathanCasey/grand_trade_auto/issues/93 'Issue #93'
+[#95]: https://github.com/JonathanCasey/grand_trade_auto/issues/95 'Issue #95'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -461,6 +461,8 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       section IDs ([#81][]).
 - [Added] Alpha Vantage added, including conf section requirement, along with
       warning that API calls may be consumed in unit tests ([#88][]).
+- [Added] Notes on config for Windows to use an older system version and
+      installing packages with right permissions added ([#96][]).
 
 
 ### Docs: README

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,16 @@ the most elegant, running
 do the trick (the last part for the plus `+` sign and onwards can be omitted if
 it is not set at all yet).
 
+In Windows, one way of using a specific version of python is to open a cmd
+prompt (not powershell) -- probably as admin -- and navigate to the desired
+older python version's folder.  Then, run
+`mklink python3.7.exe C:\path\to\python37\python.exe` to make a sym link for
+python 3.7, for example.  Now this can be evoked with `python3.7`.
+
+While the admin prompt is open, this might be the best time to install
+required pacakges with pip (can use `pip3.7` in this example) as installing as a
+user can cause some headaches...
+
 
 ### CircleCI
 If forking this project, CircleCI will need contexts setup.  See

--- a/grand_trade_auto/apic/alpaca.py
+++ b/grand_trade_auto/apic/alpaca.py
@@ -166,7 +166,7 @@ class Alpaca(broker_meta.Broker, datafeed_meta.Datafeed):
                 raise ConnectionRefusedError(msg) from ex
             except tradeapi.rest.APIError as ex:
                 msg = 'Unable to connect to Alpaca.' \
-                        + f'  API Error: {str(ex)}'
+                        + f'  API Error: {str(ex)} (Code = {str(ex.code)})'
                 logger.critical(msg)
                 raise ConnectionRefusedError(msg) from ex
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aiofiles
-alpaca-trade-api==0.51.0
+alpaca-trade-api==1.4.3
 alpha_vantage==2.3.1
 beautifulsoup4
 fastapi

--- a/tests/unit/apic/test_apics.py
+++ b/tests/unit/apic/test_apics.py
@@ -13,6 +13,8 @@ Module Attributes:
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 #pylint: disable=protected-access  # Allow for purpose of testing those elements
+#pylint: disable=use-implicit-booleaness-not-comparison
+#   +-> want to specifically check type in most tests -- `None` is a fail
 
 from grand_trade_auto.apic import alpaca
 from grand_trade_auto.apic import apics

--- a/tests/unit/database/test_databases.py
+++ b/tests/unit/database/test_databases.py
@@ -13,6 +13,8 @@ Module Attributes:
 (C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 #pylint: disable=protected-access  # Allow for purpose of testing those elements
+#pylint: disable=use-implicit-booleaness-not-comparison
+#   +-> want to specifically check type in most tests -- `None` is a fail
 
 from grand_trade_auto.database import databases
 from grand_trade_auto.database import postgres

--- a/tests/unit/general/test_config.py
+++ b/tests/unit/general/test_config.py
@@ -13,6 +13,9 @@ Module Attributes:
 
 (C) Copyright 2020 Jonathan Casey.  All Rights Reserved Worldwide.
 """
+#pylint: disable=use-implicit-booleaness-not-comparison
+#   +-> want to specifically check type in most tests -- `None` is a fail
+
 import configparser
 import logging
 import os.path


### PR DESCRIPTION
This fixes issues that came up in #94.  Specifically, it fixes pylint and alpaca issues.

The alpaca fix was a small change to the expected format of an error message.  Test did not change.  Alpaca package version updated to latest since there were some big changes on their end this year.

The pylint errors were all fixed by disabling them, but only in the affected modules.  This was done because these were all test modules.  In unit tests, do intentionally want explicit checks rather than listening to `use-implicit-booleaness-not-comparison`.

Finally, some quick tips on Windows and Python setup added.

Closes #95.  Closes #96.