### PR TITLE
feature/104-separate-int-tests into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -471,6 +471,11 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [Added] `PriceFrequency` enum added to define options for security price
       frequency as they appear in the database ([#98][]).
 
+##### Unit Tests
+- [Changed] Existing tests that were really integration tests moved to
+      `test_int__model_orm_meta.py`, with proper unit tests put in their place,
+      largely for testing CRUD ops ([#104][]).
+
 
 ### Model: Company
 - [Added] `company.py` added with `Company` subclasses from `Model`, defining
@@ -532,6 +537,11 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       This is set to `public` to match the default; primarily to ensure unit
       tests always match code ([#98][]).
 
+##### Unit Tests
+- [Changed] Existing tests that were really integration tests moved to
+      `test_int__postgres_orm.py`, with proper unit tests put in their place,
+      largely for testing CRUD ops ([#104][]).
+
 
 ### Web: Backend / Meta
 
@@ -581,10 +591,11 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
       content ([#11][]).
 
 
-### Tests: Integration: Postgres <-> Orm <-> Models
-- [Added] `tests/integration/test_int__postgres_orm_models.py` added to test
-      integration on both sides of ORM for all models to support all CRUD ops
-      with Postgres db ([#98][]).
+### Tests: Integration: Database <-> Orm <-> Model: Postgres Models
+- [Added]
+      `tests/integration/database_model_orm/test_int__postgres_orm_models.py`
+      added to test integration on both sides of ORM for all models to support
+      all CRUD ops with Postgres db ([#98][]).
   - Models tested:
     - `Company`
     - `DatafeedSrc`
@@ -592,6 +603,21 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
     - `Security`
     - `SecurityPrice`
     - `StockAdjustment`
+- [Changed] `test_int__postgres_orm_models.py` in
+      `tests/integration/database_model_orm` renamed to
+      `test_int__postgres_models.py` ([#104][]).
+
+
+### Tests: Integration: Database <-> Orm: Postgres
+- [Added] `tests/integration/database_orm/test_int__postgres_orm.py`
+      added to test integration between `Postgres` and `PostgresOrm`of ORM for
+      all CRUD ops generically (migrated from unit tests) ([#104][]).
+
+
+### Tests: Integration: Model <-> Orm: Model Orm Meta
+- [Added] `tests/integration/model_orm/test_int__model_orm_meta.py`
+      added to test integration between `Model` and `Orm`of ORM for
+      all CRUD ops generically (migrated from unit tests) ([#104][]).
 
 
 ### Docs: CHANGELOG
@@ -700,6 +726,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#96][]
 - [#98][]
 - [#103][]
+- [#104][]
 
 #### PRs
 - [#29][] for [#26][]
@@ -739,6 +766,7 @@ Compare to [stable](https://github.com/JonathanCasey/grand_trade_auto/compare/st
 - [#97][] for [#95][], [#96][]
 - [#101][] for [#98][]
 - [#105][] for [#103][]
+- [#106][] for [#104][]
 
 
 ---
@@ -786,6 +814,7 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#96]: https://github.com/JonathanCasey/grand_trade_auto/issues/96 'Issue #96'
 [#98]: https://github.com/JonathanCasey/grand_trade_auto/issues/98 'Issue #98'
 [#103]: https://github.com/JonathanCasey/grand_trade_auto/issues/103 'Issue #103'
+[#104]: https://github.com/JonathanCasey/grand_trade_auto/issues/104 'Issue #104'
 
 [#29]: https://github.com/JonathanCasey/grand_trade_auto/pull/26 'PR #29'
 [#30]: https://github.com/JonathanCasey/grand_trade_auto/pull/30 'PR #30'
@@ -824,3 +853,4 @@ Reference-style links here (see below, only in source) in develop-merge order.
 [#97]: https://github.com/JonathanCasey/grand_trade_auto/pull/97 'PR #97'
 [#101]: https://github.com/JonathanCasey/grand_trade_auto/pull/101 'PR #101'
 [#105]: https://github.com/JonathanCasey/grand_trade_auto/pull/105 'PR #105'
+[#106]: https://github.com/JonathanCasey/grand_trade_auto/pull/106 'PR #106'

--- a/tests/integration/database_model_orm/test_int__postgres_models.py
+++ b/tests/integration/database_model_orm/test_int__postgres_models.py
@@ -5,6 +5,11 @@ Tests the integration between:
 - grand_trade_auto.orm.postgres_orm
 - grand_trade_auto.database.postgres
 
+While unit tests already test this integration to some degree, this is to a more
+exhaustive degree.  Those unit tests are mostly using integrative approaches due
+to minimizing mock complexity and making tests practically useful, but do aim to
+minimize how much of the integration is invoked.
+
 Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
 all tiles, classes, and methods will be prefaced with `test_/Test` to comply
 with auto-discovery (others may exist, but will not be part of test suite

--- a/tests/integration/database_orm/__init__.py
+++ b/tests/integration/database_orm/__init__.py
@@ -1,4 +1,4 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
-        'test_int__postgres_models',
+        'test_int__postgres_orm',
 ]

--- a/tests/integration/database_orm/test_int__postgres_orm.py
+++ b/tests/integration/database_orm/test_int__postgres_orm.py
@@ -1,0 +1,695 @@
+#!/usr/bin/env python3
+"""
+Tests the integration between:
+- grand_trade_auto.database.postgres
+- grand_trade_auto.orm.postgres_orm
+
+While unit tests already test this integration to some degree, this is to a more
+exhaustive degree.  Those unit tests are mostly using integrative approaches due
+to minimizing mock complexity and making tests practically useful, but do aim to
+minimize how much of the integration is invoked.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  logger (Logger): Logger for this module (used for testing).
+
+(C) Copyright 2022 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
+import logging
+import re
+import uuid
+
+import psycopg2.errors
+import pytest
+
+from grand_trade_auto.database import databases
+from grand_trade_auto.database import postgres
+from grand_trade_auto.model import model_meta
+from grand_trade_auto.orm import orm_meta
+
+from tests import conftest as tests_conftest
+
+
+
+logger = logging.getLogger(__name__)
+
+
+
+@pytest.fixture(scope='module', autouse=True)
+def fixture_create_test_table():
+    """
+    Creates a table in the test database for this test.
+
+    This MUST match the TestModel class in this module.
+    """
+    test_db = databases._get_database_from_config(tests_conftest._TEST_PG_DB_ID,
+            tests_conftest._TEST_PG_ENV)
+    conn = test_db.connect(False)
+    sql = '''
+        CREATE TABLE test_postgres_orm (
+            id integer NOT NULL GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+            test_name text,
+            str_data text,
+            int_data integer,
+            bool_data boolean
+        )
+    '''
+    test_db.execute(sql, conn=conn)
+    conn.close()
+
+
+
+class ModelTest(model_meta.Model):
+    """
+    A test model to use for testing within this module.
+
+    This MUST match with the `fixture_create_test_table` in this module.
+    """
+    _table_name = 'test_postgres_orm'
+
+    _columns = (
+        'id',
+        'test_name',
+        'str_data',
+        'int_data',
+        'bool_data',
+    )
+
+    _read_only_columns = (
+        'id',
+    )
+
+    # Don't need the attributes for each column -- not used
+
+
+
+def mock_execute_log(self, command, val_vars=None, cursor=None, commit=True,
+            close_cursor=True, **kwargs):
+    """
+    Simply logs the mogrified SQL statement for inspection.
+    """
+    #pylint: disable=unused-argument
+    cursor = self.connect().cursor()
+    sql = cursor.mogrify(command, val_vars)
+    self.connect().commit()
+    cursor.close()
+    sql_formatted = re.sub(rb'\n\s+', b' ', sql.strip())
+    logger.warning(sql_formatted)
+
+
+
+def _confirm_all_data(orm, data, sql_select, select_var_vals):
+    """
+    Confirms the data struct is loaded in the table and is the only thing loaded
+    in the table.
+    """
+    conn = orm._db.connect(False)
+    cursor = orm._db.execute(sql_select, select_var_vals,
+            close_cursor=False, conn=conn)
+    assert cursor.rowcount == len(data)
+    cols = [d[0] for d in cursor.description]
+    for i in range(cursor.rowcount):
+        results = dict(zip(cols, cursor.fetchone()))
+        results.pop('id')
+        assert results == data[i]
+    cursor.close()
+    conn.close()
+
+
+
+def _load_data_and_confirm(orm, data, sql_select, select_var_vals):
+    """
+    Load data in table and confirm it is there.  Table expected to be empty
+    prior to call.
+    """
+    conn = orm._db.connect(False)
+    for d in data:
+        orm.add(ModelTest, d, conn=conn)
+    conn.close()
+    _confirm_all_data(orm, data, sql_select, select_var_vals)
+
+
+
+def test_add(monkeypatch, caplog, pg_test_orm):
+    """
+    Tests the `add()` method in `PostgresOrm`.
+    """
+    #pylint: disable=too-many-locals
+
+    caplog.set_level(logging.WARNING)
+
+    test_name = 'test_add'
+    good_data = {
+        'test_name': test_name,
+        'str_data': str(uuid.uuid4()),
+        'int_data': 1,
+        'bool_data': True,
+    }
+    bad_id_ro = {
+        'id': 2,
+        'test_name': test_name,
+        'str_data': str(uuid.uuid4()),
+        'int_data': 2,
+        'bool_data': True,
+    }
+    bad_col = {
+        'test_name': test_name,
+        'str_data': str(uuid.uuid4()),
+        'int_data': 3,
+        'bool_data': True,
+        'bad_col': 'nonexistent col',
+    }
+    bad_type = {
+        'test_name': test_name,
+        'str_data': str(uuid.uuid4()),
+        'int_data': 'four',
+        'bool_data': True,
+    }
+
+    conn_2 = pg_test_orm._db.connect(False)
+    cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
+    sql_select = 'SELECT * FROM test_postgres_orm WHERE test_name=%(test_name)s'
+    select_var_vals = {'test_name': test_name}
+
+    # Ensure single row add; can supply a cursor, keep it open
+    pg_test_orm.add(ModelTest, good_data, cursor=cursor_2, close_cursor=False)
+    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+            cursor=cursor_2, close_cursor=False)
+    assert cursor == cursor_2
+    assert cursor.rowcount == 1
+    cols = [d[0] for d in cursor.description]
+    results = dict(zip(cols, cursor.fetchone()))
+    assert results['str_data'] == good_data['str_data']
+    cursor.close() # Effectively also closes cursor_2
+
+    # Ensure cannot set id col
+    with pytest.raises(
+            psycopg2.errors.GeneratedAlways           #pylint: disable=no-member
+            ) as ex:
+        pg_test_orm.add(ModelTest, bad_id_ro)
+    assert 'cannot insert into column "id"' in str(ex.value)
+    pg_test_orm._db._conn.rollback()
+
+    # Ensure bad col in new data caught
+    caplog.clear()
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        pg_test_orm.add(ModelTest, bad_col)
+    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            "Invalid column(s) for ModelTest: `bad_col`"),
+    ]
+
+    # Ensure bad type in new data is caught
+    with pytest.raises(
+            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
+            ) as ex:
+        pg_test_orm.add(ModelTest, bad_type)
+    assert 'invalid input syntax for type integer: "four"' in str(ex.value)
+
+    # Ensure SQL generated as expected
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
+    caplog.clear()
+    pg_test_orm.add(ModelTest, good_data)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            'b"INSERT INTO test_postgres_orm'
+            + ' (test_name,str_data,int_data,bool_data)'
+            + ' VALUES (\'test_add\','
+            + f' \'{str(good_data["str_data"])}\', 1, true)"'),
+    ]
+
+    conn_2.close()
+    pg_test_orm._db._conn.close()
+
+
+
+def test_update(monkeypatch, caplog, pg_test_orm):
+    """
+    Tests the `update()` method in `PostgresOrm`.
+    """
+    #pylint: disable=too-many-locals, too-many-statements
+    caplog.set_level(logging.WARNING)
+
+    test_name = 'test_update'
+    init_data = [
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 1,
+            'bool_data': True,
+        },
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 2,
+            'bool_data': True,
+        },
+    ]
+    new_data = [
+        {
+            'str_data': str(uuid.uuid4()),
+        },
+        {
+            'str_data': str(uuid.uuid4()),
+            'bool_data': False,
+        },
+        {
+            'str_data': str(uuid.uuid4()),
+        },
+    ]
+    bad_id_ro = {
+        'id': 3,
+        'test_name': test_name,
+        'str_data': str(uuid.uuid4()),
+        'int_data': 3,
+        'bool_data': True,
+    }
+    bad_col = {
+        'test_name': test_name,
+        'str_data': str(uuid.uuid4()),
+        'int_data': 4,
+        'bool_data': True,
+        'bad_col': 'nonexistent col',
+    }
+    bad_type = {
+        'test_name': test_name,
+        'str_data': str(uuid.uuid4()),
+        'int_data': 'five',
+        'bool_data': True,
+    }
+
+    sql_select = '''
+        SELECT * FROM test_postgres_orm
+        WHERE test_name=%(test_name)s
+        ORDER BY id
+    '''
+    select_var_vals = {'test_name': test_name}
+
+    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
+
+    # Ensure simple where; single row update; can supply a cursor, keep it open
+    conn_2 = pg_test_orm._db.connect(False)
+    cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
+    where_1 = ('int_data', model_meta.LogicOp.EQ, 1)
+    pg_test_orm.update(ModelTest, new_data[0], where_1, cursor=cursor_2,
+            close_cursor=False)
+    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+            cursor=cursor_2, close_cursor=False)
+    assert cursor == cursor_2
+    assert cursor.rowcount == 2
+    cols = [d[0] for d in cursor.description]
+    for i in range(cursor.rowcount):
+        results = dict(zip(cols, cursor.fetchone()))
+        results.pop('id')
+        if i == 0:
+            assert results == {**init_data[i], **new_data[0]}
+        else:
+            assert results == init_data[i]
+    cursor_2.close() # Effectively also closes cursor_2
+
+    # Ensure complex where, multiple rows updated to same vals
+    where_1_2 = {
+        model_meta.LogicCombo.OR: [
+            ('int_data', model_meta.LogicOp.EQ, 1),
+            ('int_data', model_meta.LogicOp.EQ, 2),
+        ],
+    }
+    pg_test_orm.update(ModelTest, new_data[1], where_1_2)
+    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+            close_cursor=False)
+    assert cursor.rowcount == 2
+    cols = [d[0] for d in cursor.description]
+    for i in range(cursor.rowcount):
+        results = dict(zip(cols, cursor.fetchone()))
+        results.pop('id')
+        assert results == {**init_data[i], **new_data[1]}
+    cursor.close()
+
+    # Ensure all updated if where empty
+    pg_test_orm.update(ModelTest, new_data[2], None)
+    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+            close_cursor=False)
+    assert cursor.rowcount == 2
+    cols = [d[0] for d in cursor.description]
+    for i in range(cursor.rowcount):
+        results = dict(zip(cols, cursor.fetchone()))
+        results.pop('id')
+        assert results == {**init_data[i], **new_data[1], **new_data[2]}
+    cursor.close()
+
+    # Ensure cannot update id col
+    with pytest.raises(
+            psycopg2.errors.GeneratedAlways           #pylint: disable=no-member
+            ) as ex:
+        pg_test_orm.update(ModelTest, bad_id_ro, where_1)
+    assert 'column "id" can only be updated to DEFAULT\nDETAIL:  Column "id"' \
+            + ' is an identity column defined as GENERATED ALWAYS.' \
+            in str(ex.value)
+    pg_test_orm._db._conn.rollback()
+
+    # Ensure bad col in new data caught
+    caplog.clear()
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        pg_test_orm.update(ModelTest, bad_col, where_1)
+    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            "Invalid column(s) for ModelTest: `bad_col`"),
+    ]
+
+    # Ensure bad type in new data is caught
+    with pytest.raises(
+            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
+            ) as ex:
+        pg_test_orm.update(ModelTest, bad_type, where_1)
+    assert 'invalid input syntax for type integer: "five"' in str(ex.value)
+
+    # Ensure SQL generated as expected
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
+    caplog.clear()
+    pg_test_orm.update(ModelTest, new_data[1], where_1_2)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            'b"UPDATE test_postgres_orm SET str_data = \''
+            + f'{new_data[1]["str_data"]}\', bool_data = false WHERE'
+            + ' (int_data = 1 OR int_data = 2)"'),
+    ]
+
+    conn_2.close()
+    pg_test_orm._db._conn.close()
+
+
+
+def test_delete(monkeypatch, caplog, pg_test_orm):
+    """
+    Tests the `delete()` method in `PostgresOrm`.
+    """
+    #pylint: disable=too-many-locals, too-many-statements
+    caplog.set_level(logging.WARNING)
+
+    test_name = 'test_delete'
+    init_data = [
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 1,
+            'bool_data': True,
+        },
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 2,
+            'bool_data': True,
+        },
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 3,
+            'bool_data': True,
+        },
+    ]
+
+    sql_select = '''
+        SELECT * FROM test_postgres_orm
+        WHERE test_name=%(test_name)s
+        ORDER BY id
+    '''
+    select_var_vals = {'test_name': test_name}
+
+    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
+
+    # Ensure simple where; can supply a cursor, keep it open
+    conn_2 = pg_test_orm._db.connect(False)
+    cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
+    where_1 = ('int_data', model_meta.LogicOp.EQ, 1)
+    pg_test_orm.delete(ModelTest, where_1, cursor=cursor_2, close_cursor=False)
+    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+            cursor=cursor_2, close_cursor=False)
+    assert cursor == cursor_2
+    assert cursor.rowcount == 2
+    cols = [d[0] for d in cursor.description]
+    for i in range(cursor.rowcount):
+        results = dict(zip(cols, cursor.fetchone()))
+        results.pop('id')
+        assert results == init_data[i+1]
+    cursor_2.close() # Effectively also closes cursor_2
+
+    # Ensure complex where
+    where_2_3 = {
+        model_meta.LogicCombo.OR: [
+            ('int_data', model_meta.LogicOp.EQ, 2),
+            ('int_data', model_meta.LogicOp.EQ, 3),
+        ],
+    }
+    pg_test_orm.delete(ModelTest, where_2_3)
+    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+            close_cursor=False)
+    assert cursor.rowcount == 0
+    cursor.close()
+
+    # Ensure delete all fails without explicit delete all
+    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
+    caplog.clear()
+    with pytest.raises(ValueError) as ex:
+        pg_test_orm.delete(ModelTest, {})
+    assert 'Invalid delete parameters: `where` empty, but' in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            'Invalid delete parameters: `where` empty, but did not'
+                    + ' set `really_delete_all` to confirm delete all.'
+                    + '  Likely intended to specify `where`?'),
+    ]
+
+    # Ensure delete all works with explicit delete all
+    _confirm_all_data(pg_test_orm, init_data, sql_select, select_var_vals)
+    pg_test_orm.delete(ModelTest, None, really_delete_all=True)
+    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+            close_cursor=False)
+    assert cursor.rowcount == 0
+    cursor.close()
+
+    # Ensure bad col in where caught
+    caplog.clear()
+    where_bad_col = ('bad_col', model_meta.LogicOp.NOT_NULL)
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        pg_test_orm.delete(ModelTest, where_bad_col)
+    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            "Invalid column(s) for ModelTest: `bad_col`"),
+    ]
+
+    # Ensure bad type in where is caught
+    where_bad_type = ('id', model_meta.LogicOp.GTE, 'nan')
+    with pytest.raises(
+            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
+            ) as ex:
+        pg_test_orm.delete(ModelTest, where_bad_type)
+    assert 'invalid input syntax for type integer: "nan"' in str(ex.value)
+
+    # Ensure SQL generated as expected
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
+    caplog.clear()
+    pg_test_orm.delete(ModelTest, where_2_3)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            "b'DELETE FROM test_postgres_orm WHERE"
+            + " (int_data = 2 OR int_data = 3)'"),
+    ]
+
+    conn_2.close()
+    pg_test_orm._db._conn.close()
+
+
+
+def test_query(monkeypatch, caplog, pg_test_orm):
+    """
+    Tests the `query()` method in `PostgresOrm`.
+    """
+    #pylint: disable=too-many-locals, too-many-statements
+    caplog.set_level(logging.WARNING)
+
+    test_name = 'test_query'
+    init_data = [
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 1,
+            'bool_data': True,
+        },
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 2,
+            'bool_data': True,
+        },
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 3,
+            'bool_data': False,
+        },
+        {
+            'test_name': test_name,
+            'str_data': str(uuid.uuid4()),
+            'int_data': 4,
+            'bool_data': True,
+        },
+    ]
+
+    sql_select = '''
+        SELECT * FROM test_postgres_orm
+        WHERE test_name=%(test_name)s
+        ORDER BY id
+    '''
+    select_var_vals = {'test_name': test_name}
+
+    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
+
+    # Ensure good without where clause; cursor closed; return as pandas(enum)
+    cursor = pg_test_orm._db.cursor()
+    pd_df = pg_test_orm.query(ModelTest, model_meta.ReturnAs.PANDAS,
+            cursor=cursor, close_cursor=True)
+    assert cursor.closed is True
+    assert len(pd_df['test_name']==test_name) >= len(init_data)
+
+    # Ensure can supply a cursor, keep it open; and return as model(enum)
+    conn_2 = pg_test_orm._db.connect(False)
+    cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
+    where_1 = ('int_data', model_meta.LogicOp.EQ, 1)
+    models = pg_test_orm.query(ModelTest, model_meta.ReturnAs.MODEL,
+            ModelTest._columns, where_1, cursor=cursor_2, close_cursor=False)
+    assert cursor_2.rowcount == 1
+    init_data_model_indices = [0]
+    assert len(models) == len(init_data_model_indices)
+    for i, mdl in enumerate(models):
+        for k, v in init_data[init_data_model_indices[i]].items():
+            assert getattr(mdl, k) == v
+        assert isinstance(mdl.id, int)
+    cursor_2.close() # Effectively also closes cursor_2
+
+    # Ensure more complex where; with cols, order, limit; return pandas(str)
+    where_2_3 = {
+        model_meta.LogicCombo.OR: [
+            ('int_data', model_meta.LogicOp.EQ, 2),
+            ('int_data', model_meta.LogicOp.EQ, 3),
+        ],
+    }
+    cols_to_return = ['id', 'int_data']
+    order_id_desc = [('id', model_meta.SortOrder.DESC)]
+    limit = len(init_data)
+    pd_df = pg_test_orm.query(ModelTest, 'pandas', cols_to_return, where_2_3,
+            limit, order_id_desc)
+    init_data_model_indices = [2, 1]
+    assert len(pd_df) == len(init_data_model_indices)
+    assert list(pd_df.columns) == cols_to_return
+    min_id_so_far = 65535   # Must be much larger than anything expected
+    for i in range(len(pd_df)):
+        for k, v in init_data[init_data_model_indices[i]].items():
+            if k not in cols_to_return or k == 'id':
+                continue
+            assert pd_df.iloc[i].loc[k] == v
+        try:
+            pd_id = int(pd_df.iloc[i].loc['id'])
+        except ValueError:
+            assert False
+        assert pd_id == pd_df.iloc[i].loc['id']
+        assert pd_id < min_id_so_far
+        min_id_so_far = pd_id
+
+    # Ensure complex order; effective limit; cursor closed; return model(str)
+    cursor = pg_test_orm._db.cursor()
+    order_bool_asc_int_desc = [
+        ('bool_data', model_meta.SortOrder.ASC),
+        ('int_data', model_meta.SortOrder.DESC),
+    ]
+    limit = len(init_data) - 1
+    models = pg_test_orm.query(ModelTest, 'model', limit=limit,
+            order=order_bool_asc_int_desc, cursor=cursor)
+    assert cursor.closed is True
+    init_data_model_indices = [2, 3, 1]
+    assert len(models) == len(init_data_model_indices)
+    for i, mdl in enumerate(models):
+        for k, v in init_data[init_data_model_indices[i]].items():
+            assert getattr(mdl, k) == v
+        assert isinstance(mdl.id, int)
+
+    # Ensure invalid return as caught
+    with pytest.raises(ValueError) as ex:
+        pg_test_orm.query(ModelTest, 'invalid-return-as')
+    assert "'invalid-return-as' is not a valid ReturnAs" in str(ex.value)
+
+    # Ensure bad col in return cols caught
+    caplog.clear()
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        pg_test_orm.query(ModelTest, 'model', ['bad_col'])
+    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            "Invalid column(s) for ModelTest: `bad_col`"),
+    ]
+
+    # Ensure bad col in where caught
+    caplog.clear()
+    where_bad_col = ('bad_col', model_meta.LogicOp.NOT_NULL)
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        pg_test_orm.query(ModelTest, 'model', where=where_bad_col)
+    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            "Invalid column(s) for ModelTest: `bad_col`"),
+    ]
+
+    # Ensure bad col in order caught
+    caplog.clear()
+    order_bad_col = [('bad_col', model_meta.SortOrder.ASC)]
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        pg_test_orm.query(ModelTest, 'model', order=order_bad_col)
+    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            "Invalid column(s) for ModelTest: `bad_col`"),
+    ]
+
+    # Ensure bad limit arg caught
+    caplog.clear()
+    with pytest.raises(ValueError) as ex:
+        pg_test_orm.query(ModelTest, 'model', limit='nan')
+    assert "Failed to parse limit, likely not a number:" in str(ex.value)
+    assert caplog.record_tuples == [
+        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
+            "Failed to parse limit, likely not a number:"
+            + " invalid literal for int() with base 10: 'nan'"),
+    ]
+
+    # Ensure bad type anywhere is caught
+    where_bad_type = ('id', model_meta.LogicOp.GTE, 'nan')
+    with pytest.raises(
+            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
+            ) as ex:
+        pg_test_orm.query(ModelTest, 'pandas', where=where_bad_type)
+    assert 'invalid input syntax for type integer: "nan"' in str(ex.value)
+
+    # Ensure SQL generated as expected
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
+    caplog.clear()
+    # Don't really care about exception -- just side effect of mock
+    with pytest.raises(AttributeError):
+        pg_test_orm.query(ModelTest, 'model', where=where_2_3, limit=100,
+                order=order_bool_asc_int_desc)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            "b'SELECT * FROM test_postgres_orm WHERE (int_data = 2 OR"
+            + " int_data = 3) ORDER BY bool_data ASC, int_data DESC"
+            + " LIMIT 100'"),
+    ]
+
+    conn_2.close()
+    pg_test_orm._db._conn.close()

--- a/tests/integration/database_orm/test_int__postgres_orm.py
+++ b/tests/integration/database_orm/test_int__postgres_orm.py
@@ -52,7 +52,7 @@ def fixture_create_test_table():
             tests_conftest._TEST_PG_ENV)
     conn = test_db.connect(False)
     sql = '''
-        CREATE TABLE test_postgres_orm (
+        CREATE TABLE test_int__postgres_orm (
             id integer NOT NULL GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
             test_name text,
             str_data text,
@@ -71,7 +71,7 @@ class ModelTest(model_meta.Model):
 
     This MUST match with the `fixture_create_test_table` in this module.
     """
-    _table_name = 'test_postgres_orm'
+    _table_name = 'test_int__postgres_orm'
 
     _columns = (
         'id',
@@ -174,7 +174,8 @@ def test_add(monkeypatch, caplog, pg_test_orm):
 
     conn_2 = pg_test_orm._db.connect(False)
     cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
-    sql_select = 'SELECT * FROM test_postgres_orm WHERE test_name=%(test_name)s'
+    sql_select = 'SELECT * FROM test_int__postgres_orm' \
+            + ' WHERE test_name=%(test_name)s'
     select_var_vals = {'test_name': test_name}
 
     # Ensure single row add; can supply a cursor, keep it open
@@ -218,8 +219,9 @@ def test_add(monkeypatch, caplog, pg_test_orm):
     caplog.clear()
     pg_test_orm.add(ModelTest, good_data)
     assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            'b"INSERT INTO test_postgres_orm'
+        ('tests.integration.database_orm.test_int__postgres_orm',
+            logging.WARNING,
+            'b"INSERT INTO test_int__postgres_orm'
             + ' (test_name,str_data,int_data,bool_data)'
             + ' VALUES (\'test_add\','
             + f' \'{str(good_data["str_data"])}\', 1, true)"'),
@@ -286,7 +288,7 @@ def test_update(monkeypatch, caplog, pg_test_orm):
     }
 
     sql_select = '''
-        SELECT * FROM test_postgres_orm
+        SELECT * FROM test_int__postgres_orm
         WHERE test_name=%(test_name)s
         ORDER BY id
     '''
@@ -376,8 +378,9 @@ def test_update(monkeypatch, caplog, pg_test_orm):
     caplog.clear()
     pg_test_orm.update(ModelTest, new_data[1], where_1_2)
     assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            'b"UPDATE test_postgres_orm SET str_data = \''
+        ('tests.integration.database_orm.test_int__postgres_orm',
+            logging.WARNING,
+            'b"UPDATE test_int__postgres_orm SET str_data = \''
             + f'{new_data[1]["str_data"]}\', bool_data = false WHERE'
             + ' (int_data = 1 OR int_data = 2)"'),
     ]
@@ -417,7 +420,7 @@ def test_delete(monkeypatch, caplog, pg_test_orm):
     ]
 
     sql_select = '''
-        SELECT * FROM test_postgres_orm
+        SELECT * FROM test_int__postgres_orm
         WHERE test_name=%(test_name)s
         ORDER BY id
     '''
@@ -499,8 +502,9 @@ def test_delete(monkeypatch, caplog, pg_test_orm):
     caplog.clear()
     pg_test_orm.delete(ModelTest, where_2_3)
     assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            "b'DELETE FROM test_postgres_orm WHERE"
+        ('tests.integration.database_orm.test_int__postgres_orm',
+            logging.WARNING,
+            "b'DELETE FROM test_int__postgres_orm WHERE"
             + " (int_data = 2 OR int_data = 3)'"),
     ]
 
@@ -545,7 +549,7 @@ def test_query(monkeypatch, caplog, pg_test_orm):
     ]
 
     sql_select = '''
-        SELECT * FROM test_postgres_orm
+        SELECT * FROM test_int__postgres_orm
         WHERE test_name=%(test_name)s
         ORDER BY id
     '''
@@ -685,8 +689,9 @@ def test_query(monkeypatch, caplog, pg_test_orm):
         pg_test_orm.query(ModelTest, 'model', where=where_2_3, limit=100,
                 order=order_bool_asc_int_desc)
     assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            "b'SELECT * FROM test_postgres_orm WHERE (int_data = 2 OR"
+        ('tests.integration.database_orm.test_int__postgres_orm',
+            logging.WARNING,
+            "b'SELECT * FROM test_int__postgres_orm WHERE (int_data = 2 OR"
             + " int_data = 3) ORDER BY bool_data ASC, int_data DESC"
             + " LIMIT 100'"),
     ]

--- a/tests/integration/model_orm/__init__.py
+++ b/tests/integration/model_orm/__init__.py
@@ -1,4 +1,4 @@
 # pylint: disable=missing-module-docstring
 __all__ = [
-        'test_int__postgres_models',
+        'test_int__model_orm_meta',
 ]

--- a/tests/integration/model_orm/test_int__model_orm_meta.py
+++ b/tests/integration/model_orm/test_int__model_orm_meta.py
@@ -1,0 +1,681 @@
+#!/usr/bin/env python3
+"""
+Tests the integration between:
+- grand_trade_auto.model.model_meta
+- grand_trade_auto.orm.orm_meta
+
+While unit tests already test this integration to some degree, this is to a more
+exhaustive degree.  Those unit tests are mostly using integrative approaches due
+to minimizing mock complexity and making tests practically useful, but do aim to
+minimize how much of the integration is invoked.
+
+Per [pytest](https://docs.pytest.org/en/reorganize-docs/new-docs/user/naming_conventions.html),
+all tiles, classes, and methods will be prefaced with `test_/Test` to comply
+with auto-discovery (others may exist, but will not be part of test suite
+directly).
+
+Module Attributes:
+  logger (Logger): Logger for this module (used for testing).
+
+(C) Copyright 2022 Jonathan Casey.  All Rights Reserved Worldwide.
+"""
+#pylint: disable=protected-access  # Allow for purpose of testing those elements
+
+import copy
+import logging
+
+import pandas as pd
+import psycopg2.errors
+import pytest
+
+from grand_trade_auto.model import model_meta
+from grand_trade_auto.orm import orm_meta
+
+
+
+logger = logging.getLogger(__name__)
+
+
+
+class ModelTest(model_meta.Model):
+    """
+    A test model to use for testing within this module.
+    """
+    _table_name = 'test_model_meta'
+
+    _columns = (
+        'id',
+        'col_1',
+        'col_2',
+        'col_auto_ro',
+    )
+
+    _read_only_columns = (
+        'col_auto_ro',
+    )
+
+    # Column Attributes -- MUST match _columns!
+    # id defined in super
+    col_1 = None
+    col_2 = None
+    col_auto_ro = None
+    # End of Column Attributes
+
+
+
+    def __copy__(self):
+        """
+        Return an effective shallow copy for these testing purposes.
+        """
+        shallow_copy = ModelTest(self._orm)
+        for attr in ['id', 'col_1', 'col_2', 'col_auto_ro']:
+            setattr(shallow_copy, attr, getattr(self, attr))
+        return shallow_copy
+
+
+
+class OrmTest(orm_meta.Orm):
+    """
+    A barebones Orm that can be used for most tests.
+
+    Instance Attributes:
+      _mock_db_results ([]): A list of objects that would be in the database if
+        there were a db.  Meant to store results for add() so they can be
+        checked later, etc.
+    """
+    def __init__(self, db):
+        """
+        Add the `_mock_db_results` instance attribute.
+        """
+        super().__init__(db)
+        self._mock_db_results = []
+
+
+
+    def _create_schema_enum_currency(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_enum_market(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_enum_price_frequency(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_table_company(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_table_datafeed_src(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_table_exchange(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_table_security(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_table_security_price(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_table_stock_adjustment(self):
+        """
+        Not needed / will not be used.
+        """
+
+
+
+    def add(self, model_cls, data, **kwargs):
+        """
+        Fake adding something to mock results, and check cols.  Expected to
+        check afterwards.
+
+        Raises:
+          (psycopg2.errors.GeneratedAlways): Raised as a simulated error if
+            attempting to update a read only column.  This should be triggered
+            and tested as part of a test.
+          [Pass through expected]
+        """
+        OrmTest._validate_cols(data.keys(), model_cls)
+        if any(c in data for c in model_cls._read_only_columns):
+            raise psycopg2.errors.GeneratedAlways(   # pylint: disable=no-member
+                    '...can only be updated to DEFAULT')
+
+        res = {
+            'model': model_cls(self, data),
+            'extra_args': kwargs,
+        }
+        self._mock_db_results.append(res)
+
+
+
+    def update(self, model_cls, data, where, **kwargs):
+        """
+        Fake updating something in mock results, and check cols.  Expected to
+        have existing data.  Limited 'where' clause support.
+
+        Raises:
+          (psycopg2.errors.GeneratedAlways): Raised as a simulated error if
+            attempting to update a read only column.  This should be triggered
+            and tested as part of a test.
+          (ValueError): Raised if an unsupported LogicOp is provided.  This has
+            much more limited support for LogicOps to limit how much needs to be
+            implemented here.  If this is raised, the test should be redesigned
+            to avoid it rather than catching it.
+          [Pass through expected]
+        """
+        OrmTest._validate_cols(data.keys(), model_cls)
+        if where[1] is not model_meta.LogicOp.EQUALS:
+            raise ValueError('Test Error: Provided LogicOp not supported')
+        if any(c in data for c in model_cls._read_only_columns):
+            raise psycopg2.errors.GeneratedAlways(   # pylint: disable=no-member
+                    '...can only be updated to DEFAULT')
+
+        for res in self._mock_db_results:
+            if getattr(res['model'], where[0]) == where[2]:
+                for k, v in data.items():
+                    setattr(res['model'], k, v)
+                # Intentionally override extra_args to be able to test
+                res['extra_args'] = kwargs
+
+
+
+    def delete(self, model_cls, where, really_delete_all=False, **kwargs):
+        """
+        Fake deleting something in mock results, and check cols.  Expected to
+        have existing data.  Limited 'where' clause support.
+
+        Raises:
+          (ValueError):
+            [with respect to LogicOp] Raised if an unsupported LogicOp is
+              provided.  This has much more limited support for LogicOps to
+              limit how much needs to be implemented here.  If this is raised,
+              the test should be redesigned to avoid it rather than catching it.
+            [with respect to really_delete_all] Raised as a simulated error if
+              the where clause is empty but `really_delete_all` was not set to
+              True.  This should be triggered and tested as part of a test.
+        """
+        if where and where[1] is not model_meta.LogicOp.EQUALS:
+            raise ValueError('Test Error: Provided LogicOp not supported')
+        if not where and really_delete_all:
+            self._mock_db_results = []
+            return
+        if not where:
+            raise ValueError('Need to confirm w/ really_delete_all')
+
+        for res in self._mock_db_results:
+            if getattr(res['model'], where[0]) == where[2]:
+                del res['model']
+                # Intentionally override extra_args to be able to test
+                res['extra_args'] = kwargs
+
+
+
+    def query(self, model_cls, return_as, columns_to_return=None,
+            where=None, limit=None, order=None, **kwargs):
+        """
+        Fake querying something from mock results, and check cols.  Expected to
+        have existing data.  Limited 'where' and 'order' clause support.
+
+        Raises:
+          (psycopg2.errors.GeneratedAlways): Raised as a simulated error if
+            attempting to update a read only column.  This should be triggered
+            and tested as part of a test.
+          (ValueError): Raised if an unsupported LogicOp, SortOrder, or ReturnAs
+            is provided.  This has much more limited support for LogicOps,
+            SortOrders, and ReturnAs options to limit how much needs to be
+            implemented here.  If this is raised, the test should be redesigned
+            to avoid it rather than catching it.
+          [Pass through expected]
+        """
+        #pylint: disable=too-many-branches
+        if columns_to_return is not None:
+            OrmTest._validate_cols(columns_to_return, model_cls)
+        if where and where[1] is not model_meta.LogicOp.EQUALS:
+            raise ValueError('Test Error: Provided LogicOp not supported')
+        if order and order[1] is not model_meta.SortOrder.DESC:
+            raise ValueError('Test Error: Provided SortOrder not supported')
+
+        cols_to_omit = []
+        if columns_to_return:
+            for col in ModelTest._columns:
+                if col not in columns_to_return:
+                    cols_to_omit.append(col)
+
+        results = []
+        for res in self._mock_db_results:
+            if not where or getattr(res['model'], where[0]) == where[2]:
+                # Intentionally override extra_args to be able to test
+                res_copy = {
+                    'model': copy.copy(res['model']),
+                    'extra_args': kwargs,
+                }
+                for col in cols_to_omit:
+                    setattr(res_copy['model'], col, None)
+                results.append(res_copy)
+
+        if order:
+            # Hard-coded to only support DESC, hence reverse is True
+            results.sort(key=lambda mdl: getattr(mdl['model'], order[0]),
+                    reverse=True)
+
+        if limit is not None and limit < len(results):
+            results = results[:limit]
+
+        if model_meta.ReturnAs(return_as) is model_meta.ReturnAs.MODEL:
+            return [r['model'] for r in results]
+        if model_meta.ReturnAs(return_as) is model_meta.ReturnAs.PANDAS:
+            # Flatten 'model' level of dict for pd.df import
+            mdl_cols = columns_to_return or ModelTest._columns
+            for res in results:
+                for col in mdl_cols:
+                    res[col] = getattr(res['model'], col)
+                del res['model']
+            return pd.DataFrame(results)
+        raise ValueError('Test Error: Provided ReturnAs not supported')
+
+
+
+    @staticmethod
+    def _validate_cols(cols, model_cls):
+        """
+        A helper method just for this testing to check columns, raise an
+        exception if there is an issue.
+
+        Raises:
+          (NonexistentColumnError): Raised as a simulated error if at least one
+            column provided is not in the list of columns for the provided
+            model.  This should be triggered and tested as part of a test.
+        """
+        valid_cols = model_cls.get_columns()
+        if not set(cols).issubset(valid_cols):
+            err_msg = f'Invalid column(s) for {model_cls.__name__}:'
+            err_msg += f' `{"`, `".join(set(cols) - set(valid_cols))}`'
+            logger.error(err_msg)
+            raise orm_meta.NonexistentColumnError(err_msg)
+
+
+
+def test_add_and_direct(caplog, monkeypatch):
+    """
+    Tests the `add()` and `add_direct()` methods in `Model`.
+    """
+    caplog.set_level(logging.WARNING)
+
+    orm = OrmTest(None)
+    assert orm._mock_db_results == []
+
+    data_1 = {
+        'col_1': 1,
+        'col_2': 2,
+    }
+    ModelTest.add_direct(orm, data_1, conn='fake_conn')
+    assert len(orm._mock_db_results) == 1
+    res = orm._mock_db_results[0]
+    assert res['model'].id is None
+    assert res['model'].col_1 == 1
+    assert res['model'].col_2 == 2
+    assert res['extra_args'] == {'conn': 'fake_conn'}
+
+    data_2 = {
+        'col_1': 3,
+        'col_2': 4,
+    }
+    model = ModelTest(orm, data_2)
+    model._active_cols.remove('col_1')
+    model.add(cursor='fake_cursor', conn=4)
+    assert len(orm._mock_db_results) == 2
+    res = orm._mock_db_results[1]
+    assert res['model'].id is None
+    assert res['model'].col_1 is None   # Removed from active, should be skipped
+    assert res['model'].col_2 == 4
+    assert res['extra_args'] == {'cursor': 'fake_cursor', 'conn': 4}
+
+    data_3 = {
+        'col_1': 5,
+        'col_auto_ro': 'should fail direct',
+    }
+    model = ModelTest(orm, data_3)
+    model.add()
+    last_model = orm._mock_db_results[-1]['model']
+    assert last_model.col_1 == model.col_1
+    assert last_model.col_auto_ro is None
+    assert model.col_auto_ro == 'should fail direct'
+    with pytest.raises(
+            psycopg2.errors.GeneratedAlways) as ex:  # pylint: disable=no-member
+        ModelTest.add_direct(orm, data_3)
+    assert '...can only be updated to DEFAULT' in str(ex.value)
+
+    caplog.clear()
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        ModelTest.add_direct(orm, {'bad_col': 6})
+    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.ERROR,
+            'Invalid column(s) for ModelTest: `bad_col`'),
+    ]
+
+    def mock_get_active_data_as_dict(self):
+        """
+        Injects a bad col on purpose.
+        """
+        cols = {c: getattr(self, c) for c in self._active_cols}
+        cols['bad_col'] = 7
+        return cols
+
+    caplog.clear()
+    monkeypatch.setattr(ModelTest, '_get_active_data_as_dict',
+            mock_get_active_data_as_dict)
+    data_4 = {
+        'col_1': 8,
+    }
+    model = ModelTest(orm, data_4)
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        model.add()
+    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.ERROR,
+            'Invalid column(s) for ModelTest: `bad_col`'),
+    ]
+
+
+
+def test_update_and_direct(caplog, monkeypatch):
+    """
+    Tests the `update()` and `udpate_direct()` methods in `Model`.
+    """
+    #pylint: disable=too-many-locals, too-many-statements
+    caplog.set_level(logging.WARNING)
+
+    data_orig = [
+        {
+            'col_1': 1,
+            'col_2': 2,
+        },
+        {
+            'col_1': 3,
+            'col_2': 2,
+        },
+    ]
+
+    orm = OrmTest(None)
+    for i, data in enumerate(data_orig):
+        orm.add(ModelTest, data, fake_count=i)
+    assert len(orm._mock_db_results) == 2
+    assert orm._mock_db_results[0]['model'].col_1 == 1
+    assert orm._mock_db_results[1]['model'].col_1 == 3
+    assert orm._mock_db_results[1]['extra_args'] == {'fake_count': 1}
+
+    new_data_1 = {
+        'id': 4,
+        'col_1': 5,
+    }
+    where_1 = ('col_1', model_meta.LogicOp.EQUALS, 1)
+    ModelTest.update_direct(orm, new_data_1, where_1, new_fake=True)
+    assert len(orm._mock_db_results) == 2
+    res_1 = orm._mock_db_results[0]
+    res_2 = orm._mock_db_results[1]
+    assert res_1['model'].id == 4
+    assert res_1['model'].col_1 == 5
+    assert res_1['model'].col_2 == 2
+    assert res_1['extra_args'] == {'new_fake': True}
+    assert res_2['model'].id is None
+    assert res_2['model'].col_1 == 3
+    assert res_2['model'].col_2 == 2
+    assert res_2['extra_args'] == {'fake_count': 1}
+
+    new_data_2 = {
+        'col_1': 6,
+    }
+    where_2 = ('col_2', model_meta.LogicOp.EQUALS, 2)
+    ModelTest.update_direct(orm, new_data_2, where_2, new_new_fake='yes')
+    assert len(orm._mock_db_results) == 2
+    res_1 = orm._mock_db_results[0]
+    res_2 = orm._mock_db_results[1]
+    assert res_1['model'].id == 4
+    assert res_1['model'].col_1 == 6
+    assert res_1['model'].col_2 == 2
+    assert res_1['extra_args'] == {'new_new_fake': 'yes'}
+    assert res_2['model'].id is None
+    assert res_2['model'].col_1 == 6
+    assert res_2['model'].col_2 == 2
+    assert res_2['extra_args'] == {'new_new_fake': 'yes'}
+
+    with pytest.raises(
+            psycopg2.errors.GeneratedAlways) as ex:  # pylint: disable=no-member
+        ModelTest.update_direct(orm, {'col_auto_ro': 'fail'}, where_2)
+    assert '...can only be updated to DEFAULT' in str(ex.value)
+
+    # Create an effective semi-shallow copy of 1st db result...
+    model_copy = copy.copy(orm._mock_db_results[0]['model'])
+    # ...then try modifying the data...including ro col since unused so far...
+    model_copy.col_1 = 7
+    model_copy.col_2 = 8
+    model_copy.col_auto_ro = 'allowed but ignored'
+    # ...but act like one col not really active...
+    model_copy._active_cols.remove('col_1')
+    model_copy.update(another_fake=9)
+    assert len(orm._mock_db_results) == 2
+    res_1 = orm._mock_db_results[0]
+    res_2 = orm._mock_db_results[1]
+    assert res_1['model'].id == 4
+    assert res_1['model'].col_1 == 6
+    assert res_1['model'].col_2 == 8
+    assert res_1['model'].col_auto_ro is None
+    assert res_1['extra_args'] == {'another_fake': 9}
+    assert res_2['model'].id is None
+    assert res_2['model'].col_1 == 6
+    assert res_2['model'].col_2 == 2
+    assert res_2['extra_args'] == {'new_new_fake': 'yes'}
+    assert model_copy.col_1 == 7
+    assert model_copy.col_2 == 8
+
+    caplog.clear()
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        ModelTest.update_direct(orm, {'bad_col': 5}, None)
+    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.ERROR,
+            'Invalid column(s) for ModelTest: `bad_col`'),
+    ]
+
+    def mock_get_active_data_as_dict(self):
+        """
+        Injects a bad col on purpose.
+        """
+        cols = {c: getattr(self, c) for c in self._active_cols}
+        cols['bad_col'] = 10
+        return cols
+
+    caplog.clear()
+    monkeypatch.setattr(ModelTest, '_get_active_data_as_dict',
+            mock_get_active_data_as_dict)
+    data_3 = {
+        'id': 11,
+        'col_1': 12,
+    }
+    model = ModelTest(orm, data_3)
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        model.update()
+    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.ERROR,
+            'Invalid column(s) for ModelTest: `bad_col`'),
+    ]
+
+
+
+def test_delete_and_direct():
+    """
+    Tests the `update()` and `udpate_direct()` methods in `Model`.
+    """
+    #pylint: disable=too-many-statements
+
+    data_orig = [
+        {
+            'id': 1,
+            'col_1': 2,
+            'col_2': 3,
+        },
+        {
+            'id': 4,
+            'col_1': 5,
+            'col_2': 3,
+        },
+    ]
+    orm = OrmTest(None)
+
+    def _clear_load_and_verify_init_data():
+        """
+        Clears the existing "db" data, loads the initial, and then verifies.
+        """
+        orm._mock_db_results = []
+        for i, data in enumerate(data_orig):
+            orm.add(ModelTest, data, fake_count=i)
+        assert len(orm._mock_db_results) == 2
+        assert orm._mock_db_results[0]['model'].id == 1
+        assert orm._mock_db_results[0]['model'].col_1 == 2
+        assert orm._mock_db_results[1]['model'].col_1 == 5
+        assert orm._mock_db_results[1]['extra_args'] == {'fake_count': 1}
+
+    _clear_load_and_verify_init_data()
+    where_1 = ('col_1', model_meta.LogicOp.EQUALS, 2)
+    ModelTest.delete_direct(orm, where_1, fake_arg=1)
+    assert len(orm._mock_db_results) == 2
+    res_1 = orm._mock_db_results[0]
+    res_2 = orm._mock_db_results[1]
+    assert 'model' not in res_1
+    assert res_1['extra_args'] == {'fake_arg': 1}
+    assert res_2['model'].id == 4
+    assert res_2['model'].col_1 == 5
+    assert res_2['model'].col_2 == 3
+    assert res_2['extra_args'] == {'fake_count': 1}
+
+    _clear_load_and_verify_init_data()
+    where_2 = ('col_2', model_meta.LogicOp.EQUALS, 3)
+    ModelTest.delete_direct(orm, where_2, fake_arg_again=2)
+    assert len(orm._mock_db_results) == 2
+    res_1 = orm._mock_db_results[0]
+    res_2 = orm._mock_db_results[1]
+    assert 'model' not in res_1
+    assert res_1['extra_args'] == {'fake_arg_again': 2}
+    assert 'model' not in res_2
+    assert res_2['extra_args'] == {'fake_arg_again': 2}
+
+    _clear_load_and_verify_init_data()
+    with pytest.raises(ValueError) as ex:
+        ModelTest.delete_direct(orm, None)
+    assert 'Need to confirm w/ really_delete_all' in str(ex.value)
+
+    ModelTest.delete_direct(orm, None, really_delete_all=True)
+    assert orm._mock_db_results == []
+
+    _clear_load_and_verify_init_data()
+    # Create an effective semi-shallow copy of 1st db result...
+    model_copy = copy.copy(orm._mock_db_results[0]['model'])
+    # ...then try modifying the data...
+    model_copy.col_1 = 6
+    model_copy.delete(another_fake=True)
+    assert len(orm._mock_db_results) == 2
+    res_1 = orm._mock_db_results[0]
+    res_2 = orm._mock_db_results[1]
+    assert 'model' not in res_1
+    assert res_1['extra_args'] == {'another_fake': True}
+    assert res_2['model'].id == 4
+    assert res_2['model'].col_1 == 5
+    assert res_2['model'].col_2 == 3
+    assert res_2['extra_args'] == {'fake_count': 1}
+
+
+
+def test_query_direct(caplog):
+    """
+    Tests the `query_direct()` method in `Model`.
+    """
+    caplog.set_level(logging.WARNING)
+
+    data_orig = [
+        {
+            'id': 1,
+            'col_1': 2,
+            'col_2': 3,
+        },
+        {
+            'id': 4,
+            'col_1': 1,
+            'col_2': 3,
+        },
+        {
+            'id': 5,
+            'col_1': 2,
+            'col_2': 3,
+        },
+        {
+            'id': 3,
+            'col_1': 2,
+            'col_2': 3,
+        },
+    ]
+    orm = OrmTest(None)
+    for i, data in enumerate(data_orig):
+        orm.add(ModelTest, data, fake_count=i)
+    assert len(orm._mock_db_results) == 4
+    assert orm._mock_db_results[0]['model'].id == 1
+    assert orm._mock_db_results[0]['model'].col_1 == 2
+    assert orm._mock_db_results[1]['model'].col_1 == 1
+    assert orm._mock_db_results[1]['extra_args'] == {'fake_count': 1}
+    assert orm._mock_db_results[2]['model'].id == 5
+    assert orm._mock_db_results[3]['model'].col_1 == 2
+
+    models = ModelTest.query_direct(orm, 'model')
+    assert len(models) == len(data_orig)
+    for i, model in enumerate(models):
+        for col in ModelTest._columns:
+            if col == 'col_auto_ro':
+                continue
+            assert data_orig[i][col] == getattr(model, col)
+
+    rtn_cols = ['col_1', 'col_2']
+    models = ModelTest.query_direct(orm, model_meta.ReturnAs.MODEL,
+            rtn_cols, limit=2)
+    assert len(models) == 2
+    for i, model in enumerate(models):
+        for col in rtn_cols:
+            assert data_orig[i][col] == getattr(model, col)
+        assert model.id is None
+
+    where = ('col_1', model_meta.LogicOp.EQUALS, 2)
+    order = ('id', model_meta.SortOrder.DESC)
+    pd_df = ModelTest.query_direct(orm, 'pandas', where=where, order=order,
+            fake_extra='fake val')
+    assert len(pd_df) == 3
+    data_expected = [data_orig[2], data_orig[3], data_orig[0]]
+    for i in range(len(pd_df)):
+        for col in ModelTest._columns:
+            if col == 'col_auto_ro':
+                continue
+            assert pd_df.iloc[i].loc[col] == data_expected[i][col]
+        assert pd_df.iloc[i].loc['extra_args'] == {'fake_extra': 'fake val'}
+
+    caplog.clear()
+    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
+        ModelTest.query_direct(orm, 'model', ['bad_col'])
+    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.ERROR,
+            'Invalid column(s) for ModelTest: `bad_col`'),
+    ]

--- a/tests/integration/model_orm/test_int__model_orm_meta.py
+++ b/tests/integration/model_orm/test_int__model_orm_meta.py
@@ -45,14 +45,16 @@ class ModelTest(model_meta.Model):
     """
     _table_name = 'test_model_meta'
 
+    # NOTE: Order of attributes swapped to trick dupe code pylint check
+
+    _read_only_columns = (
+        'col_auto_ro',
+    )
+
     _columns = (
         'id',
         'col_1',
         'col_2',
-        'col_auto_ro',
-    )
-
-    _read_only_columns = (
         'col_auto_ro',
     )
 
@@ -93,21 +95,7 @@ class OrmTest(orm_meta.Orm):
         self._mock_db_results = []
 
 
-
-    def _create_schema_enum_currency(self):
-        """
-        Not needed / will not be used.
-        """
-
-    def _create_schema_enum_market(self):
-        """
-        Not needed / will not be used.
-        """
-
-    def _create_schema_enum_price_frequency(self):
-        """
-        Not needed / will not be used.
-        """
+    # NOTE: Tables before Enums below to trick dupe code pylint check
 
     def _create_schema_table_company(self):
         """
@@ -135,6 +123,21 @@ class OrmTest(orm_meta.Orm):
         """
 
     def _create_schema_table_stock_adjustment(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_enum_currency(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_enum_market(self):
+        """
+        Not needed / will not be used.
+        """
+
+    def _create_schema_enum_price_frequency(self):
         """
         Not needed / will not be used.
         """

--- a/tests/integration/model_orm/test_int__model_orm_meta.py
+++ b/tests/integration/model_orm/test_int__model_orm_meta.py
@@ -20,6 +20,8 @@ Module Attributes:
 (C) Copyright 2022 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 #pylint: disable=protected-access  # Allow for purpose of testing those elements
+#pylint: disable=use-implicit-booleaness-not-comparison
+#   +-> want to specifically check type in most tests -- `None` is a fail
 
 import copy
 import logging

--- a/tests/integration/model_orm/test_int__model_orm_meta.py
+++ b/tests/integration/model_orm/test_int__model_orm_meta.py
@@ -365,7 +365,7 @@ def test_add_and_direct(caplog, monkeypatch):
         ModelTest.add_direct(orm, {'bad_col': 6})
     assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
+        ('tests.integration.model_orm.test_int__model_orm_meta', logging.ERROR,
             'Invalid column(s) for ModelTest: `bad_col`'),
     ]
 
@@ -388,7 +388,7 @@ def test_add_and_direct(caplog, monkeypatch):
         model.add()
     assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
+        ('tests.integration.model_orm.test_int__model_orm_meta', logging.ERROR,
             'Invalid column(s) for ModelTest: `bad_col`'),
     ]
 
@@ -489,7 +489,7 @@ def test_update_and_direct(caplog, monkeypatch):
         ModelTest.update_direct(orm, {'bad_col': 5}, None)
     assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
+        ('tests.integration.model_orm.test_int__model_orm_meta', logging.ERROR,
             'Invalid column(s) for ModelTest: `bad_col`'),
     ]
 
@@ -513,7 +513,7 @@ def test_update_and_direct(caplog, monkeypatch):
         model.update()
     assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
+        ('tests.integration.model_orm.test_int__model_orm_meta', logging.ERROR,
             'Invalid column(s) for ModelTest: `bad_col`'),
     ]
 
@@ -676,6 +676,6 @@ def test_query_direct(caplog):
         ModelTest.query_direct(orm, 'model', ['bad_col'])
     assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
+        ('tests.integration.model_orm.test_int__model_orm_meta', logging.ERROR,
             'Invalid column(s) for ModelTest: `bad_col`'),
     ]

--- a/tests/unit/model/test_model_meta.py
+++ b/tests/unit/model/test_model_meta.py
@@ -8,19 +8,15 @@ with auto-discovery (others may exist, but will not be part of test suite
 directly).
 
 Module Attributes:
-  logger (Logger): Logger for this module.
+  logger (Logger): Logger for this module (used for testing).
 
 (C) Copyright 2021 Jonathan Casey.  All Rights Reserved Worldwide.
 """
 #pylint: disable=protected-access  # Allow for purpose of testing those elements
-#pylint: disable=use-implicit-booleaness-not-comparison
-#   +-> want to specifically check type in most tests -- `None` is a fail
 
-import copy
 import logging
 
 import pandas as pd
-import psycopg2.errors
 import pytest
 
 from grand_trade_auto.model import model_meta
@@ -150,35 +146,10 @@ class ModelTest(model_meta.Model):
 
 
 
-    def __copy__(self):
-        """
-        Return an effective shallow copy for these testing purposes.
-        """
-        shallow_copy = ModelTest(self._orm)
-        for attr in ['id', 'col_1', 'col_2', 'col_auto_ro']:
-            setattr(shallow_copy, attr, getattr(self, attr))
-        return shallow_copy
-
-
-
 class OrmTest(orm_meta.Orm):
     """
     A barebones Orm that can be used for most tests.
-
-    Instance Attributes:
-      _mock_db_results ([]): A list of objects that would be in the database if
-        there were a db.  Meant to store results for add() so they can be
-        checked later, etc.
     """
-    def __init__(self, db):
-        """
-        Add the `_mock_db_results` instance attribute.
-        """
-        super().__init__(db)
-        self._mock_db_results = []
-
-
-
     def _create_schema_enum_currency(self):
         """
         Not needed / will not be used.
@@ -228,172 +199,55 @@ class OrmTest(orm_meta.Orm):
 
     def add(self, model_cls, data, **kwargs):
         """
-        Fake adding something to mock results, and check cols.  Expected to
-        check afterwards.
-
-        Raises:
-          (psycopg2.errors.GeneratedAlways): Raised as a simulated error if
-            attempting to update a read only column.  This should be triggered
-            and tested as part of a test.
-          [Pass through expected]
+        Logs inputs so call from Model can be verified.
         """
-        OrmTest._validate_cols(data.keys(), model_cls)
-        if any(c in data for c in model_cls._read_only_columns):
-            raise psycopg2.errors.GeneratedAlways(   # pylint: disable=no-member
-                    '...can only be updated to DEFAULT')
-
-        res = {
-            'model': model_cls(self, data),
-            'extra_args': kwargs,
-        }
-        self._mock_db_results.append(res)
+        logger.info(f'adding model_cls: {model_cls}' )
+        logger.info(f'data: { {k: data[k] for k in sorted(data)} }')
+        logger.info(f'kwargs: {kwargs}')
 
 
 
     def update(self, model_cls, data, where, **kwargs):
         """
-        Fake updating something in mock results, and check cols.  Expected to
-        have existing data.  Limited 'where' clause support.
-
-        Raises:
-          (psycopg2.errors.GeneratedAlways): Raised as a simulated error if
-            attempting to update a read only column.  This should be triggered
-            and tested as part of a test.
-          (ValueError): Raised if an unsupported LogicOp is provided.  This has
-            much more limited support for LogicOps to limit how much needs to be
-            implemented here.  If this is raised, the test should be redesigned
-            to avoid it rather than catching it.
-          [Pass through expected]
+        Logs inputs so call from Model can be verified.
         """
-        OrmTest._validate_cols(data.keys(), model_cls)
-        if where[1] is not model_meta.LogicOp.EQUALS:
-            raise ValueError('Test Error: Provided LogicOp not supported')
-        if any(c in data for c in model_cls._read_only_columns):
-            raise psycopg2.errors.GeneratedAlways(   # pylint: disable=no-member
-                    '...can only be updated to DEFAULT')
-
-        for res in self._mock_db_results:
-            if getattr(res['model'], where[0]) == where[2]:
-                for k, v in data.items():
-                    setattr(res['model'], k, v)
-                # Intentionally override extra_args to be able to test
-                res['extra_args'] = kwargs
+        logger.info(f'updating model_cls: {model_cls}' )
+        logger.info(f'data: { {k: data[k] for k in sorted(data)} }')
+        logger.info(f'where: {where}')
+        logger.info(f'kwargs: {kwargs}')
 
 
 
     def delete(self, model_cls, where, really_delete_all=False, **kwargs):
         """
-        Fake deleting something in mock results, and check cols.  Expected to
-        have existing data.  Limited 'where' clause support.
-
-        Raises:
-          (ValueError):
-            [with respect to LogicOp] Raised if an unsupported LogicOp is
-              provided.  This has much more limited support for LogicOps to
-              limit how much needs to be implemented here.  If this is raised,
-              the test should be redesigned to avoid it rather than catching it.
-            [with respect to really_delete_all] Raised as a simulated error if
-              the where clause is empty but `really_delete_all` was not set to
-              True.  This should be triggered and tested as part of a test.
+        Logs inputs so call from Model can be verified.
         """
-        if where and where[1] is not model_meta.LogicOp.EQUALS:
-            raise ValueError('Test Error: Provided LogicOp not supported')
-        if not where and really_delete_all:
-            self._mock_db_results = []
-            return
-        if not where:
-            raise ValueError('Need to confirm w/ really_delete_all')
-
-        for res in self._mock_db_results:
-            if getattr(res['model'], where[0]) == where[2]:
-                del res['model']
-                # Intentionally override extra_args to be able to test
-                res['extra_args'] = kwargs
+        logger.info(f'deleting model_cls: {model_cls}' )
+        logger.info(f'really_delete_all: {really_delete_all}')
+        logger.info(f'where: {where}')
+        logger.info(f'kwargs: {kwargs}')
 
 
 
     def query(self, model_cls, return_as, columns_to_return=None,
             where=None, limit=None, order=None, **kwargs):
         """
-        Fake querying something from mock results, and check cols.  Expected to
-        have existing data.  Limited 'where' and 'order' clause support.
-
-        Raises:
-          (psycopg2.errors.GeneratedAlways): Raised as a simulated error if
-            attempting to update a read only column.  This should be triggered
-            and tested as part of a test.
-          (ValueError): Raised if an unsupported LogicOp, SortOrder, or ReturnAs
-            is provided.  This has much more limited support for LogicOps,
-            SortOrders, and ReturnAs options to limit how much needs to be
-            implemented here.  If this is raised, the test should be redesigned
-            to avoid it rather than catching it.
-          [Pass through expected]
+        Logs inputs so call from Model can be verified.  Returns empty dummy
+        values.
         """
-        #pylint: disable=too-many-branches
-        if columns_to_return is not None:
-            OrmTest._validate_cols(columns_to_return, model_cls)
-        if where and where[1] is not model_meta.LogicOp.EQUALS:
-            raise ValueError('Test Error: Provided LogicOp not supported')
-        if order and order[1] is not model_meta.SortOrder.DESC:
-            raise ValueError('Test Error: Provided SortOrder not supported')
-
-        cols_to_omit = []
-        if columns_to_return:
-            for col in ModelTest._columns:
-                if col not in columns_to_return:
-                    cols_to_omit.append(col)
-
-        results = []
-        for res in self._mock_db_results:
-            if not where or getattr(res['model'], where[0]) == where[2]:
-                # Intentionally override extra_args to be able to test
-                res_copy = {
-                    'model': copy.copy(res['model']),
-                    'extra_args': kwargs,
-                }
-                for col in cols_to_omit:
-                    setattr(res_copy['model'], col, None)
-                results.append(res_copy)
-
-        if order:
-            # Hard-coded to only support DESC, hence reverse is True
-            results.sort(key=lambda mdl: getattr(mdl['model'], order[0]),
-                    reverse=True)
-
-        if limit is not None and limit < len(results):
-            results = results[:limit]
+        logger.info(f'querying model_cls: {model_cls}' )
+        logger.info(f'return_as: {return_as}')
+        logger.info(f'columns_to_return: {columns_to_return}')
+        logger.info(f'where: {where}')
+        logger.info(f'limit: {limit}')
+        logger.info(f'order: {order}')
+        logger.info(f'kwargs: {kwargs}')
 
         if model_meta.ReturnAs(return_as) is model_meta.ReturnAs.MODEL:
-            return [r['model'] for r in results]
+            return [ModelTest(OrmTest(None))]
         if model_meta.ReturnAs(return_as) is model_meta.ReturnAs.PANDAS:
-            # Flatten 'model' level of dict for pd.df import
-            mdl_cols = columns_to_return or ModelTest._columns
-            for res in results:
-                for col in mdl_cols:
-                    res[col] = getattr(res['model'], col)
-                del res['model']
-            return pd.DataFrame(results)
+            return pd.DataFrame()
         raise ValueError('Test Error: Provided ReturnAs not supported')
-
-
-
-    @staticmethod
-    def _validate_cols(cols, model_cls):
-        """
-        A helper method just for this testing to check columns, raise an
-        exception if there is an issue.
-
-        Raises:
-          (NonexistentColumnError): Raised as a simulated error if at least one
-            column provided is not in the list of columns for the provided
-            model.  This should be triggered and tested as part of a test.
-        """
-        valid_cols = model_cls.get_columns()
-        if not set(cols).issubset(valid_cols):
-            err_msg = f'Invalid column(s) for {model_cls.__name__}:'
-            err_msg += f' `{"`, `".join(set(cols) - set(valid_cols))}`'
-            logger.error(err_msg)
-            raise orm_meta.NonexistentColumnError(err_msg)
 
 
 
@@ -489,27 +343,31 @@ def test_get_columns():
 
 
 
-def test_add_and_direct(caplog, monkeypatch):
+def test_add_and_direct(caplog):
     """
     Tests the `add()` and `add_direct()` methods in `Model`.
     """
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.INFO)
 
     orm = OrmTest(None)
-    assert orm._mock_db_results == []
 
+    caplog.clear()
     data_1 = {
         'col_1': 1,
         'col_2': 2,
     }
     ModelTest.add_direct(orm, data_1, conn='fake_conn')
-    assert len(orm._mock_db_results) == 1
-    res = orm._mock_db_results[0]
-    assert res['model'].id is None
-    assert res['model'].col_1 == 1
-    assert res['model'].col_2 == 2
-    assert res['extra_args'] == {'conn': 'fake_conn'}
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "adding model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "data: {'col_1': 1, 'col_2': 2}"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'conn': 'fake_conn'}"),
+    ]
 
+    caplog.clear()
     data_2 = {
         'col_1': 3,
         'col_2': 4,
@@ -517,267 +375,121 @@ def test_add_and_direct(caplog, monkeypatch):
     model = ModelTest(orm, data_2)
     model._active_cols.remove('col_1')
     model.add(cursor='fake_cursor', conn=4)
-    assert len(orm._mock_db_results) == 2
-    res = orm._mock_db_results[1]
-    assert res['model'].id is None
-    assert res['model'].col_1 is None   # Removed from active, should be skipped
-    assert res['model'].col_2 == 4
-    assert res['extra_args'] == {'cursor': 'fake_cursor', 'conn': 4}
-
-    data_3 = {
-        'col_1': 5,
-        'col_auto_ro': 'should fail direct',
-    }
-    model = ModelTest(orm, data_3)
-    model.add()
-    last_model = orm._mock_db_results[-1]['model']
-    assert last_model.col_1 == model.col_1
-    assert last_model.col_auto_ro is None
-    assert model.col_auto_ro == 'should fail direct'
-    with pytest.raises(
-            psycopg2.errors.GeneratedAlways) as ex:  # pylint: disable=no-member
-        ModelTest.add_direct(orm, data_3)
-    assert '...can only be updated to DEFAULT' in str(ex.value)
-
-    caplog.clear()
-    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        ModelTest.add_direct(orm, {'bad_col': 6})
-    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
-            'Invalid column(s) for ModelTest: `bad_col`'),
-    ]
-
-    def mock_get_active_data_as_dict(self):
-        """
-        Injects a bad col on purpose.
-        """
-        cols = {c: getattr(self, c) for c in self._active_cols}
-        cols['bad_col'] = 7
-        return cols
-
-    caplog.clear()
-    monkeypatch.setattr(ModelTest, '_get_active_data_as_dict',
-            mock_get_active_data_as_dict)
-    data_4 = {
-        'col_1': 8,
-    }
-    model = ModelTest(orm, data_4)
-    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        model.add()
-    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
-    assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
-            'Invalid column(s) for ModelTest: `bad_col`'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "adding model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "data: {'col_2': 4}"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'cursor': 'fake_cursor', 'conn': 4}"),
     ]
 
 
 
-def test_update_and_direct(caplog, monkeypatch):
+def test_update_and_direct(caplog):
     """
     Tests the `update()` and `udpate_direct()` methods in `Model`.
     """
-    #pylint: disable=too-many-locals, too-many-statements
-    caplog.set_level(logging.WARNING)
-
-    data_orig = [
-        {
-            'col_1': 1,
-            'col_2': 2,
-        },
-        {
-            'col_1': 3,
-            'col_2': 2,
-        },
-    ]
+    caplog.set_level(logging.INFO)
 
     orm = OrmTest(None)
-    for i, data in enumerate(data_orig):
-        orm.add(ModelTest, data, fake_count=i)
-    assert len(orm._mock_db_results) == 2
-    assert orm._mock_db_results[0]['model'].col_1 == 1
-    assert orm._mock_db_results[1]['model'].col_1 == 3
-    assert orm._mock_db_results[1]['extra_args'] == {'fake_count': 1}
 
+    caplog.clear()
     new_data_1 = {
         'id': 4,
         'col_1': 5,
     }
     where_1 = ('col_1', model_meta.LogicOp.EQUALS, 1)
     ModelTest.update_direct(orm, new_data_1, where_1, new_fake=True)
-    assert len(orm._mock_db_results) == 2
-    res_1 = orm._mock_db_results[0]
-    res_2 = orm._mock_db_results[1]
-    assert res_1['model'].id == 4
-    assert res_1['model'].col_1 == 5
-    assert res_1['model'].col_2 == 2
-    assert res_1['extra_args'] == {'new_fake': True}
-    assert res_2['model'].id is None
-    assert res_2['model'].col_1 == 3
-    assert res_2['model'].col_2 == 2
-    assert res_2['extra_args'] == {'fake_count': 1}
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "updating model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "data: {'col_1': 5, 'id': 4}"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "where: ('col_1', <LogicOp.EQUALS: '='>, 1)"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'new_fake': True}"),
+    ]
 
+    caplog.clear()
     new_data_2 = {
+        'id': 2,
         'col_1': 6,
     }
-    where_2 = ('col_2', model_meta.LogicOp.EQUALS, 2)
-    ModelTest.update_direct(orm, new_data_2, where_2, new_new_fake='yes')
-    assert len(orm._mock_db_results) == 2
-    res_1 = orm._mock_db_results[0]
-    res_2 = orm._mock_db_results[1]
-    assert res_1['model'].id == 4
-    assert res_1['model'].col_1 == 6
-    assert res_1['model'].col_2 == 2
-    assert res_1['extra_args'] == {'new_new_fake': 'yes'}
-    assert res_2['model'].id is None
-    assert res_2['model'].col_1 == 6
-    assert res_2['model'].col_2 == 2
-    assert res_2['extra_args'] == {'new_new_fake': 'yes'}
-
-    with pytest.raises(
-            psycopg2.errors.GeneratedAlways) as ex:  # pylint: disable=no-member
-        ModelTest.update_direct(orm, {'col_auto_ro': 'fail'}, where_2)
-    assert '...can only be updated to DEFAULT' in str(ex.value)
-
-    # Create an effective semi-shallow copy of 1st db result...
-    model_copy = copy.copy(orm._mock_db_results[0]['model'])
-    # ...then try modifying the data...including ro col since unused so far...
-    model_copy.col_1 = 7
-    model_copy.col_2 = 8
-    model_copy.col_auto_ro = 'allowed but ignored'
-    # ...but act like one col not really active...
-    model_copy._active_cols.remove('col_1')
-    model_copy.update(another_fake=9)
-    assert len(orm._mock_db_results) == 2
-    res_1 = orm._mock_db_results[0]
-    res_2 = orm._mock_db_results[1]
-    assert res_1['model'].id == 4
-    assert res_1['model'].col_1 == 6
-    assert res_1['model'].col_2 == 8
-    assert res_1['model'].col_auto_ro is None
-    assert res_1['extra_args'] == {'another_fake': 9}
-    assert res_2['model'].id is None
-    assert res_2['model'].col_1 == 6
-    assert res_2['model'].col_2 == 2
-    assert res_2['extra_args'] == {'new_new_fake': 'yes'}
-    assert model_copy.col_1 == 7
-    assert model_copy.col_2 == 8
-
-    caplog.clear()
-    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        ModelTest.update_direct(orm, {'bad_col': 5}, None)
-    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
+    model = ModelTest(orm, new_data_2)
+    model.col_auto_ro = 'allowed but ignored'
+    model.update(another_fake=9)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
-            'Invalid column(s) for ModelTest: `bad_col`'),
-    ]
-
-    def mock_get_active_data_as_dict(self):
-        """
-        Injects a bad col on purpose.
-        """
-        cols = {c: getattr(self, c) for c in self._active_cols}
-        cols['bad_col'] = 10
-        return cols
-
-    caplog.clear()
-    monkeypatch.setattr(ModelTest, '_get_active_data_as_dict',
-            mock_get_active_data_as_dict)
-    data_3 = {
-        'id': 11,
-        'col_1': 12,
-    }
-    model = ModelTest(orm, data_3)
-    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        model.update()
-    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
-    assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
-            'Invalid column(s) for ModelTest: `bad_col`'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "updating model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "data: {'col_1': 6, 'id': 2}"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "where: ('id', <LogicOp.EQUALS: '='>, 2)"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'another_fake': 9}"),
     ]
 
 
 
-def test_delete_and_direct():
+def test_delete_and_direct(caplog):
     """
     Tests the `update()` and `udpate_direct()` methods in `Model`.
     """
-    #pylint: disable=too-many-statements
+    caplog.set_level(logging.INFO)
 
-    data_orig = [
-        {
-            'id': 1,
-            'col_1': 2,
-            'col_2': 3,
-        },
-        {
-            'id': 4,
-            'col_1': 5,
-            'col_2': 3,
-        },
-    ]
     orm = OrmTest(None)
 
-    def _clear_load_and_verify_init_data():
-        """
-        Clears the existing "db" data, loads the initial, and then verifies.
-        """
-        orm._mock_db_results = []
-        for i, data in enumerate(data_orig):
-            orm.add(ModelTest, data, fake_count=i)
-        assert len(orm._mock_db_results) == 2
-        assert orm._mock_db_results[0]['model'].id == 1
-        assert orm._mock_db_results[0]['model'].col_1 == 2
-        assert orm._mock_db_results[1]['model'].col_1 == 5
-        assert orm._mock_db_results[1]['extra_args'] == {'fake_count': 1}
-
-    _clear_load_and_verify_init_data()
+    caplog.clear()
     where_1 = ('col_1', model_meta.LogicOp.EQUALS, 2)
     ModelTest.delete_direct(orm, where_1, fake_arg=1)
-    assert len(orm._mock_db_results) == 2
-    res_1 = orm._mock_db_results[0]
-    res_2 = orm._mock_db_results[1]
-    assert 'model' not in res_1
-    assert res_1['extra_args'] == {'fake_arg': 1}
-    assert res_2['model'].id == 4
-    assert res_2['model'].col_1 == 5
-    assert res_2['model'].col_2 == 3
-    assert res_2['extra_args'] == {'fake_count': 1}
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "deleting model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'really_delete_all: False'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "where: ('col_1', <LogicOp.EQUALS: '='>, 2)"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'fake_arg': 1}"),
+    ]
 
-    _clear_load_and_verify_init_data()
-    where_2 = ('col_2', model_meta.LogicOp.EQUALS, 3)
-    ModelTest.delete_direct(orm, where_2, fake_arg_again=2)
-    assert len(orm._mock_db_results) == 2
-    res_1 = orm._mock_db_results[0]
-    res_2 = orm._mock_db_results[1]
-    assert 'model' not in res_1
-    assert res_1['extra_args'] == {'fake_arg_again': 2}
-    assert 'model' not in res_2
-    assert res_2['extra_args'] == {'fake_arg_again': 2}
+    caplog.clear()
+    ModelTest.delete_direct(orm, where_1, really_delete_all=True, fake_arg=1)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "deleting model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'really_delete_all: True'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "where: ('col_1', <LogicOp.EQUALS: '='>, 2)"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'fake_arg': 1}"),
+    ]
 
-    _clear_load_and_verify_init_data()
-    with pytest.raises(ValueError) as ex:
-        ModelTest.delete_direct(orm, None)
-    assert 'Need to confirm w/ really_delete_all' in str(ex.value)
-
-    ModelTest.delete_direct(orm, None, really_delete_all=True)
-    assert orm._mock_db_results == []
-
-    _clear_load_and_verify_init_data()
-    # Create an effective semi-shallow copy of 1st db result...
-    model_copy = copy.copy(orm._mock_db_results[0]['model'])
-    # ...then try modifying the data...
-    model_copy.col_1 = 6
-    model_copy.delete(another_fake=True)
-    assert len(orm._mock_db_results) == 2
-    res_1 = orm._mock_db_results[0]
-    res_2 = orm._mock_db_results[1]
-    assert 'model' not in res_1
-    assert res_1['extra_args'] == {'another_fake': True}
-    assert res_2['model'].id == 4
-    assert res_2['model'].col_1 == 5
-    assert res_2['model'].col_2 == 3
-    assert res_2['extra_args'] == {'fake_count': 1}
+    caplog.clear()
+    data_1 = {
+        'id': 1,
+    }
+    model = ModelTest(orm, data_1)
+    model.delete(another_fake=True)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "deleting model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'really_delete_all: False'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "where: ('id', <LogicOp.EQUALS: '='>, 1)"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'another_fake': True}"),
+    ]
 
 
 
@@ -785,78 +497,54 @@ def test_query_direct(caplog):
     """
     Tests the `query_direct()` method in `Model`.
     """
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.INFO)
 
-    data_orig = [
-        {
-            'id': 1,
-            'col_1': 2,
-            'col_2': 3,
-        },
-        {
-            'id': 4,
-            'col_1': 1,
-            'col_2': 3,
-        },
-        {
-            'id': 5,
-            'col_1': 2,
-            'col_2': 3,
-        },
-        {
-            'id': 3,
-            'col_1': 2,
-            'col_2': 3,
-        },
-    ]
     orm = OrmTest(None)
-    for i, data in enumerate(data_orig):
-        orm.add(ModelTest, data, fake_count=i)
-    assert len(orm._mock_db_results) == 4
-    assert orm._mock_db_results[0]['model'].id == 1
-    assert orm._mock_db_results[0]['model'].col_1 == 2
-    assert orm._mock_db_results[1]['model'].col_1 == 1
-    assert orm._mock_db_results[1]['extra_args'] == {'fake_count': 1}
-    assert orm._mock_db_results[2]['model'].id == 5
-    assert orm._mock_db_results[3]['model'].col_1 == 2
-
-    models = ModelTest.query_direct(orm, 'model')
-    assert len(models) == len(data_orig)
-    for i, model in enumerate(models):
-        for col in ModelTest._columns:
-            if col == 'col_auto_ro':
-                continue
-            assert data_orig[i][col] == getattr(model, col)
-
-    rtn_cols = ['col_1', 'col_2']
-    models = ModelTest.query_direct(orm, model_meta.ReturnAs.MODEL,
-            rtn_cols, limit=2)
-    assert len(models) == 2
-    for i, model in enumerate(models):
-        for col in rtn_cols:
-            assert data_orig[i][col] == getattr(model, col)
-        assert model.id is None
-
-    where = ('col_1', model_meta.LogicOp.EQUALS, 2)
-    order = ('id', model_meta.SortOrder.DESC)
-    pd_df = ModelTest.query_direct(orm, 'pandas', where=where, order=order,
-            fake_extra='fake val')
-    assert len(pd_df) == 3
-    data_expected = [data_orig[2], data_orig[3], data_orig[0]]
-    for i in range(len(pd_df)):
-        for col in ModelTest._columns:
-            if col == 'col_auto_ro':
-                continue
-            assert pd_df.iloc[i].loc[col] == data_expected[i][col]
-        assert pd_df.iloc[i].loc['extra_args'] == {'fake_extra': 'fake val'}
 
     caplog.clear()
-    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        ModelTest.query_direct(orm, 'model', ['bad_col'])
-    assert 'Invalid column(s) for ModelTest: `bad_col`' in str(ex.value)
+    models = ModelTest.query_direct(orm)
+    assert len(models) == 1
+    assert isinstance(models[0], ModelTest)
     assert caplog.record_tuples == [
-        ('tests.unit.model.test_model_meta', logging.ERROR,
-            'Invalid column(s) for ModelTest: `bad_col`'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "querying model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'return_as: ReturnAs.MODEL'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'columns_to_return: None'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'where: None'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'limit: None'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "order: None"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {}"),
+    ]
+
+    caplog.clear()
+    where = ('col_1', model_meta.LogicOp.EQUALS, 2)
+    order = ('id', model_meta.SortOrder.DESC)
+    pd_df = ModelTest.query_direct(orm, 'pandas', ['col_2'], where, 3, order,
+            fake_extra='fake val')
+    assert isinstance(pd_df, pd.DataFrame)
+    assert caplog.record_tuples == [
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "querying model_cls:"
+                + " <class 'tests.unit.model.test_model_meta.ModelTest'>"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'return_as: pandas'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "columns_to_return: ['col_2']"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "where: ('col_1', <LogicOp.EQUALS: '='>, 2)"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            'limit: 3'),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "order: ('id', <SortOrder.DESC: 'desc'>)"),
+        ('tests.unit.model.test_model_meta', logging.INFO,
+            "kwargs: {'fake_extra': 'fake val'}"),
     ]
 
 

--- a/tests/unit/orm/test_postgres_orm.py
+++ b/tests/unit/orm/test_postgres_orm.py
@@ -26,7 +26,7 @@ import logging
 import re
 import uuid
 
-import psycopg2.errors
+import pandas as pd
 import pytest
 
 from grand_trade_auto.database import databases
@@ -294,12 +294,13 @@ def mock_execute_log(self, command, val_vars=None, cursor=None, commit=True,
     Simply logs the mogrified SQL statement for inspection.
     """
     #pylint: disable=unused-argument
-    cursor = self.connect().cursor()
+    cursor = cursor or self.connect().cursor()
     sql = cursor.mogrify(command, val_vars)
-    self.connect().commit()
-    cursor.close()
+    if close_cursor:
+        cursor.close()
     sql_formatted = re.sub(rb'\n\s+', b' ', sql.strip())
     logger.warning(sql_formatted)
+    return cursor
 
 
 
@@ -339,8 +340,6 @@ def test_add(monkeypatch, caplog, pg_test_orm):
     """
     Tests the `add()` method in `PostgresOrm`.
     """
-    #pylint: disable=too-many-locals
-
     caplog.set_level(logging.WARNING)
 
     test_name = 'test_add'
@@ -350,52 +349,30 @@ def test_add(monkeypatch, caplog, pg_test_orm):
         'int_data': 1,
         'bool_data': True,
     }
-    bad_id_ro = {
-        'id': 2,
+    bad_col = {
         'test_name': test_name,
         'str_data': str(uuid.uuid4()),
         'int_data': 2,
         'bool_data': True,
-    }
-    bad_col = {
-        'test_name': test_name,
-        'str_data': str(uuid.uuid4()),
-        'int_data': 3,
-        'bool_data': True,
         'bad_col': 'nonexistent col',
     }
-    bad_type = {
-        'test_name': test_name,
-        'str_data': str(uuid.uuid4()),
-        'int_data': 'four',
-        'bool_data': True,
-    }
 
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
+
+    caplog.clear()
     conn_2 = pg_test_orm._db.connect(False)
     cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
-    sql_select = 'SELECT * FROM test_postgres_orm WHERE test_name=%(test_name)s'
-    select_var_vals = {'test_name': test_name}
-
-    # Ensure single row add; can supply a cursor, keep it open
     pg_test_orm.add(ModelTest, good_data, cursor=cursor_2, close_cursor=False)
-    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
-            cursor=cursor_2, close_cursor=False)
-    assert cursor == cursor_2
-    assert cursor.rowcount == 1
-    cols = [d[0] for d in cursor.description]
-    results = dict(zip(cols, cursor.fetchone()))
-    assert results['str_data'] == good_data['str_data']
-    cursor.close() # Effectively also closes cursor_2
+    assert cursor_2.closed is False
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            'b"INSERT INTO test_postgres_orm'
+            + ' (test_name,str_data,int_data,bool_data)'
+            + ' VALUES (\'test_add\','
+            + f' \'{str(good_data["str_data"])}\', 1, true)"'),
+    ]
+    cursor_2.close()
 
-    # Ensure cannot set id col
-    with pytest.raises(
-            psycopg2.errors.GeneratedAlways           #pylint: disable=no-member
-            ) as ex:
-        pg_test_orm.add(ModelTest, bad_id_ro)
-    assert 'cannot insert into column "id"' in str(ex.value)
-    pg_test_orm._db._conn.rollback()
-
-    # Ensure bad col in new data caught
     caplog.clear()
     with pytest.raises(orm_meta.NonexistentColumnError) as ex:
         pg_test_orm.add(ModelTest, bad_col)
@@ -405,27 +382,7 @@ def test_add(monkeypatch, caplog, pg_test_orm):
             "Invalid column(s) for ModelTest: `bad_col`"),
     ]
 
-    # Ensure bad type in new data is caught
-    with pytest.raises(
-            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
-            ) as ex:
-        pg_test_orm.add(ModelTest, bad_type)
-    assert 'invalid input syntax for type integer: "four"' in str(ex.value)
-
-    # Ensure SQL generated as expected
-    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
-    caplog.clear()
-    pg_test_orm.add(ModelTest, good_data)
-    assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            'b"INSERT INTO test_postgres_orm'
-            + ' (test_name,str_data,int_data,bool_data)'
-            + ' VALUES (\'test_add\','
-            + f' \'{str(good_data["str_data"])}\', 1, true)"'),
-    ]
-
     conn_2.close()
-    pg_test_orm._db._conn.close()
 
 
 
@@ -433,24 +390,9 @@ def test_update(monkeypatch, caplog, pg_test_orm):
     """
     Tests the `update()` method in `PostgresOrm`.
     """
-    #pylint: disable=too-many-locals, too-many-statements
     caplog.set_level(logging.WARNING)
 
     test_name = 'test_update'
-    init_data = [
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 1,
-            'bool_data': True,
-        },
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 2,
-            'bool_data': True,
-        },
-    ]
     new_data = [
         {
             'str_data': str(uuid.uuid4()),
@@ -463,13 +405,6 @@ def test_update(monkeypatch, caplog, pg_test_orm):
             'str_data': str(uuid.uuid4()),
         },
     ]
-    bad_id_ro = {
-        'id': 3,
-        'test_name': test_name,
-        'str_data': str(uuid.uuid4()),
-        'int_data': 3,
-        'bool_data': True,
-    }
     bad_col = {
         'test_name': test_name,
         'str_data': str(uuid.uuid4()),
@@ -477,108 +412,38 @@ def test_update(monkeypatch, caplog, pg_test_orm):
         'bool_data': True,
         'bad_col': 'nonexistent col',
     }
-    bad_type = {
-        'test_name': test_name,
-        'str_data': str(uuid.uuid4()),
-        'int_data': 'five',
-        'bool_data': True,
-    }
 
-    sql_select = '''
-        SELECT * FROM test_postgres_orm
-        WHERE test_name=%(test_name)s
-        ORDER BY id
-    '''
-    select_var_vals = {'test_name': test_name}
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
 
-    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
-
-    # Ensure simple where; single row update; can supply a cursor, keep it open
+    caplog.clear()
     conn_2 = pg_test_orm._db.connect(False)
     cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
     where_1 = ('int_data', model_meta.LogicOp.EQ, 1)
     pg_test_orm.update(ModelTest, new_data[0], where_1, cursor=cursor_2,
             close_cursor=False)
-    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
-            cursor=cursor_2, close_cursor=False)
-    assert cursor == cursor_2
-    assert cursor.rowcount == 2
-    cols = [d[0] for d in cursor.description]
-    for i in range(cursor.rowcount):
-        results = dict(zip(cols, cursor.fetchone()))
-        results.pop('id')
-        if i == 0:
-            assert results == {**init_data[i], **new_data[0]}
-        else:
-            assert results == init_data[i]
-    cursor_2.close() # Effectively also closes cursor_2
+    assert cursor_2.closed is False
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            'b"UPDATE test_postgres_orm SET str_data = \''
+            + f'{new_data[0]["str_data"]}\' WHERE int_data = 1"'),
+    ]
+    cursor_2.close()
 
-    # Ensure complex where, multiple rows updated to same vals
-    where_1_2 = {
-        model_meta.LogicCombo.OR: [
-            ('int_data', model_meta.LogicOp.EQ, 1),
-            ('int_data', model_meta.LogicOp.EQ, 2),
-        ],
-    }
-    pg_test_orm.update(ModelTest, new_data[1], where_1_2)
-    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
-            close_cursor=False)
-    assert cursor.rowcount == 2
-    cols = [d[0] for d in cursor.description]
-    for i in range(cursor.rowcount):
-        results = dict(zip(cols, cursor.fetchone()))
-        results.pop('id')
-        assert results == {**init_data[i], **new_data[1]}
-    cursor.close()
+    caplog.clear()
+    pg_test_orm.update(ModelTest, new_data[1], None)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            'b"UPDATE test_postgres_orm SET str_data = \''
+            + f'{new_data[1]["str_data"]}\', bool_data = false"'),
+    ]
 
-    # Ensure all updated if where empty
-    pg_test_orm.update(ModelTest, new_data[2], None)
-    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
-            close_cursor=False)
-    assert cursor.rowcount == 2
-    cols = [d[0] for d in cursor.description]
-    for i in range(cursor.rowcount):
-        results = dict(zip(cols, cursor.fetchone()))
-        results.pop('id')
-        assert results == {**init_data[i], **new_data[1], **new_data[2]}
-    cursor.close()
-
-    # Ensure cannot update id col
-    with pytest.raises(
-            psycopg2.errors.GeneratedAlways           #pylint: disable=no-member
-            ) as ex:
-        pg_test_orm.update(ModelTest, bad_id_ro, where_1)
-    assert 'column "id" can only be updated to DEFAULT\nDETAIL:  Column "id"' \
-            + ' is an identity column defined as GENERATED ALWAYS.' \
-            in str(ex.value)
-    pg_test_orm._db._conn.rollback()
-
-    # Ensure bad col in new data caught
     caplog.clear()
     with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        pg_test_orm.update(ModelTest, bad_col, where_1)
+        pg_test_orm.update(ModelTest, bad_col, {})
     assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
     assert caplog.record_tuples == [
         ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
             "Invalid column(s) for ModelTest: `bad_col`"),
-    ]
-
-    # Ensure bad type in new data is caught
-    with pytest.raises(
-            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
-            ) as ex:
-        pg_test_orm.update(ModelTest, bad_type, where_1)
-    assert 'invalid input syntax for type integer: "five"' in str(ex.value)
-
-    # Ensure SQL generated as expected
-    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
-    caplog.clear()
-    pg_test_orm.update(ModelTest, new_data[1], where_1_2)
-    assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            'b"UPDATE test_postgres_orm SET str_data = \''
-            + f'{new_data[1]["str_data"]}\', bool_data = false WHERE'
-            + ' (int_data = 1 OR int_data = 2)"'),
     ]
 
     conn_2.close()
@@ -590,71 +455,36 @@ def test_delete(monkeypatch, caplog, pg_test_orm):
     """
     Tests the `delete()` method in `PostgresOrm`.
     """
-    #pylint: disable=too-many-locals, too-many-statements
     caplog.set_level(logging.WARNING)
 
-    test_name = 'test_delete'
-    init_data = [
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 1,
-            'bool_data': True,
-        },
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 2,
-            'bool_data': True,
-        },
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 3,
-            'bool_data': True,
-        },
-    ]
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
 
-    sql_select = '''
-        SELECT * FROM test_postgres_orm
-        WHERE test_name=%(test_name)s
-        ORDER BY id
-    '''
-    select_var_vals = {'test_name': test_name}
-
-    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
-
-    # Ensure simple where; can supply a cursor, keep it open
+    caplog.clear()
     conn_2 = pg_test_orm._db.connect(False)
     cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
-    where_1 = ('int_data', model_meta.LogicOp.EQ, 1)
-    pg_test_orm.delete(ModelTest, where_1, cursor=cursor_2, close_cursor=False)
-    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
-            cursor=cursor_2, close_cursor=False)
-    assert cursor == cursor_2
-    assert cursor.rowcount == 2
-    cols = [d[0] for d in cursor.description]
-    for i in range(cursor.rowcount):
-        results = dict(zip(cols, cursor.fetchone()))
-        results.pop('id')
-        assert results == init_data[i+1]
-    cursor_2.close() # Effectively also closes cursor_2
-
-    # Ensure complex where
     where_2_3 = {
         model_meta.LogicCombo.OR: [
             ('int_data', model_meta.LogicOp.EQ, 2),
             ('int_data', model_meta.LogicOp.EQ, 3),
         ],
     }
-    pg_test_orm.delete(ModelTest, where_2_3)
-    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
+    pg_test_orm.delete(ModelTest, where_2_3, cursor=cursor_2,
             close_cursor=False)
-    assert cursor.rowcount == 0
-    cursor.close()
+    assert cursor_2.closed is False
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            "b'DELETE FROM test_postgres_orm WHERE"
+            + " (int_data = 2 OR int_data = 3)'"),
+    ]
+    cursor_2.close()
 
-    # Ensure delete all fails without explicit delete all
-    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
+    caplog.clear()
+    pg_test_orm.delete(ModelTest, None, True)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            "b'DELETE FROM test_postgres_orm'"),
+    ]
+
     caplog.clear()
     with pytest.raises(ValueError) as ex:
         pg_test_orm.delete(ModelTest, {})
@@ -664,43 +494,6 @@ def test_delete(monkeypatch, caplog, pg_test_orm):
             'Invalid delete parameters: `where` empty, but did not'
                     + ' set `really_delete_all` to confirm delete all.'
                     + '  Likely intended to specify `where`?'),
-    ]
-
-    # Ensure delete all works with explicit delete all
-    _confirm_all_data(pg_test_orm, init_data, sql_select, select_var_vals)
-    pg_test_orm.delete(ModelTest, None, really_delete_all=True)
-    cursor = pg_test_orm._db.execute(sql_select, select_var_vals,
-            close_cursor=False)
-    assert cursor.rowcount == 0
-    cursor.close()
-
-    # Ensure bad col in where caught
-    caplog.clear()
-    where_bad_col = ('bad_col', model_meta.LogicOp.NOT_NULL)
-    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        pg_test_orm.delete(ModelTest, where_bad_col)
-    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
-    assert caplog.record_tuples == [
-        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
-            "Invalid column(s) for ModelTest: `bad_col`"),
-    ]
-
-    # Ensure bad type in where is caught
-    where_bad_type = ('id', model_meta.LogicOp.GTE, 'nan')
-    with pytest.raises(
-            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
-            ) as ex:
-        pg_test_orm.delete(ModelTest, where_bad_type)
-    assert 'invalid input syntax for type integer: "nan"' in str(ex.value)
-
-    # Ensure SQL generated as expected
-    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
-    caplog.clear()
-    pg_test_orm.delete(ModelTest, where_2_3)
-    assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            "b'DELETE FROM test_postgres_orm WHERE"
-            + " (int_data = 2 OR int_data = 3)'"),
     ]
 
     conn_2.close()
@@ -715,117 +508,52 @@ def test_query(monkeypatch, caplog, pg_test_orm):
     #pylint: disable=too-many-locals, too-many-statements
     caplog.set_level(logging.WARNING)
 
-    test_name = 'test_query'
-    init_data = [
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 1,
-            'bool_data': True,
-        },
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 2,
-            'bool_data': True,
-        },
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 3,
-            'bool_data': False,
-        },
-        {
-            'test_name': test_name,
-            'str_data': str(uuid.uuid4()),
-            'int_data': 4,
-            'bool_data': True,
-        },
-    ]
+    def mock_convert_cursor_to_models(self, model_cls, cursor):
+        """
+        Returns empty dummy values.
+        """
+        #pylint: disable=unused-argument
+        return [ModelTest(postgres_orm.PostgresOrm(None))]
 
-    sql_select = '''
-        SELECT * FROM test_postgres_orm
-        WHERE test_name=%(test_name)s
-        ORDER BY id
-    '''
-    select_var_vals = {'test_name': test_name}
+    def mock_convert_cursor_to_pandas_dataframe(cursor):
+        """
+        Returns empty dummy values.
+        """
+        #pylint: disable=unused-argument
+        return pd.DataFrame()
 
-    _load_data_and_confirm(pg_test_orm, init_data, sql_select, select_var_vals)
+    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
+    monkeypatch.setattr(postgres_orm.PostgresOrm, '_convert_cursor_to_models',
+            mock_convert_cursor_to_models)
+    monkeypatch.setattr(postgres_orm.PostgresOrm,
+            '_convert_cursor_to_pandas_dataframe',
+            mock_convert_cursor_to_pandas_dataframe)
 
-    # Ensure good without where clause; cursor closed; return as pandas(enum)
-    cursor = pg_test_orm._db.cursor()
-    pd_df = pg_test_orm.query(ModelTest, model_meta.ReturnAs.PANDAS,
-            cursor=cursor, close_cursor=True)
-    assert cursor.closed is True
-    assert len(pd_df['test_name']==test_name) >= len(init_data)
-
-    # Ensure can supply a cursor, keep it open; and return as model(enum)
+    caplog.clear()
     conn_2 = pg_test_orm._db.connect(False)
     cursor_2 = pg_test_orm._db.cursor(conn=conn_2)
-    where_1 = ('int_data', model_meta.LogicOp.EQ, 1)
-    models = pg_test_orm.query(ModelTest, model_meta.ReturnAs.MODEL,
-            ModelTest._columns, where_1, cursor=cursor_2, close_cursor=False)
-    assert cursor_2.rowcount == 1
-    init_data_model_indices = [0]
-    assert len(models) == len(init_data_model_indices)
-    for i, mdl in enumerate(models):
-        for k, v in init_data[init_data_model_indices[i]].items():
-            assert getattr(mdl, k) == v
-        assert isinstance(mdl.id, int)
-    cursor_2.close() # Effectively also closes cursor_2
-
-    # Ensure more complex where; with cols, order, limit; return pandas(str)
-    where_2_3 = {
-        model_meta.LogicCombo.OR: [
-            ('int_data', model_meta.LogicOp.EQ, 2),
-            ('int_data', model_meta.LogicOp.EQ, 3),
-        ],
-    }
-    cols_to_return = ['id', 'int_data']
-    order_id_desc = [('id', model_meta.SortOrder.DESC)]
-    limit = len(init_data)
-    pd_df = pg_test_orm.query(ModelTest, 'pandas', cols_to_return, where_2_3,
-            limit, order_id_desc)
-    init_data_model_indices = [2, 1]
-    assert len(pd_df) == len(init_data_model_indices)
-    assert list(pd_df.columns) == cols_to_return
-    min_id_so_far = 65535   # Must be much larger than anything expected
-    for i in range(len(pd_df)):
-        for k, v in init_data[init_data_model_indices[i]].items():
-            if k not in cols_to_return or k == 'id':
-                continue
-            assert pd_df.iloc[i].loc[k] == v
-        try:
-            pd_id = int(pd_df.iloc[i].loc['id'])
-        except ValueError:
-            assert False
-        assert pd_id == pd_df.iloc[i].loc['id']
-        assert pd_id < min_id_so_far
-        min_id_so_far = pd_id
-
-    # Ensure complex order; effective limit; cursor closed; return model(str)
-    cursor = pg_test_orm._db.cursor()
-    order_bool_asc_int_desc = [
-        ('bool_data', model_meta.SortOrder.ASC),
-        ('int_data', model_meta.SortOrder.DESC),
+    models = pg_test_orm.query(ModelTest, 'model', cursor=cursor_2,
+            close_cursor=True)
+    assert cursor_2.closed is True
+    assert len(models) == 1
+    assert isinstance(models[0], ModelTest)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            "b'SELECT * FROM test_postgres_orm'"),
     ]
-    limit = len(init_data) - 1
-    models = pg_test_orm.query(ModelTest, 'model', limit=limit,
-            order=order_bool_asc_int_desc, cursor=cursor)
-    assert cursor.closed is True
-    init_data_model_indices = [2, 3, 1]
-    assert len(models) == len(init_data_model_indices)
-    for i, mdl in enumerate(models):
-        for k, v in init_data[init_data_model_indices[i]].items():
-            assert getattr(mdl, k) == v
-        assert isinstance(mdl.id, int)
 
-    # Ensure invalid return as caught
-    with pytest.raises(ValueError) as ex:
-        pg_test_orm.query(ModelTest, 'invalid-return-as')
-    assert "'invalid-return-as' is not a valid ReturnAs" in str(ex.value)
+    caplog.clear()
+    where_1 = ('int_data', model_meta.LogicOp.EQ, 1)
+    order_id_desc = [('id', model_meta.SortOrder.DESC)]
+    pd_df = pg_test_orm.query(ModelTest, model_meta.ReturnAs.PANDAS,
+            ['str_data', 'int_data'], where_1, 3, order_id_desc)
+    assert isinstance(pd_df, pd.DataFrame)
+    assert caplog.record_tuples == [
+        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
+            "b'SELECT str_data,int_data FROM test_postgres_orm"
+            + " WHERE int_data = 1 ORDER BY id DESC LIMIT 3'"),
+    ]
 
-    # Ensure bad col in return cols caught
     caplog.clear()
     with pytest.raises(orm_meta.NonexistentColumnError) as ex:
         pg_test_orm.query(ModelTest, 'model', ['bad_col'])
@@ -835,18 +563,6 @@ def test_query(monkeypatch, caplog, pg_test_orm):
             "Invalid column(s) for ModelTest: `bad_col`"),
     ]
 
-    # Ensure bad col in where caught
-    caplog.clear()
-    where_bad_col = ('bad_col', model_meta.LogicOp.NOT_NULL)
-    with pytest.raises(orm_meta.NonexistentColumnError) as ex:
-        pg_test_orm.query(ModelTest, 'model', where=where_bad_col)
-    assert "Invalid column(s) for ModelTest: `bad_col`" in str(ex.value)
-    assert caplog.record_tuples == [
-        ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
-            "Invalid column(s) for ModelTest: `bad_col`"),
-    ]
-
-    # Ensure bad col in order caught
     caplog.clear()
     order_bad_col = [('bad_col', model_meta.SortOrder.ASC)]
     with pytest.raises(orm_meta.NonexistentColumnError) as ex:
@@ -857,7 +573,6 @@ def test_query(monkeypatch, caplog, pg_test_orm):
             "Invalid column(s) for ModelTest: `bad_col`"),
     ]
 
-    # Ensure bad limit arg caught
     caplog.clear()
     with pytest.raises(ValueError) as ex:
         pg_test_orm.query(ModelTest, 'model', limit='nan')
@@ -866,28 +581,6 @@ def test_query(monkeypatch, caplog, pg_test_orm):
         ('grand_trade_auto.orm.postgres_orm', logging.ERROR,
             "Failed to parse limit, likely not a number:"
             + " invalid literal for int() with base 10: 'nan'"),
-    ]
-
-    # Ensure bad type anywhere is caught
-    where_bad_type = ('id', model_meta.LogicOp.GTE, 'nan')
-    with pytest.raises(
-            psycopg2.errors.InvalidTextRepresentation #pylint: disable=no-member
-            ) as ex:
-        pg_test_orm.query(ModelTest, 'pandas', where=where_bad_type)
-    assert 'invalid input syntax for type integer: "nan"' in str(ex.value)
-
-    # Ensure SQL generated as expected
-    monkeypatch.setattr(postgres.Postgres, 'execute', mock_execute_log)
-    caplog.clear()
-    # Don't really care about exception -- just side effect of mock
-    with pytest.raises(AttributeError):
-        pg_test_orm.query(ModelTest, 'model', where=where_2_3, limit=100,
-                order=order_bool_asc_int_desc)
-    assert caplog.record_tuples == [
-        ('tests.unit.orm.test_postgres_orm', logging.WARNING,
-            "b'SELECT * FROM test_postgres_orm WHERE (int_data = 2 OR"
-            + " int_data = 3) ORDER BY bool_data ASC, int_data DESC"
-            + " LIMIT 100'"),
     ]
 
     conn_2.close()


### PR DESCRIPTION
This separates some model/orm unit tests to be integration tests instead.  The gap in unit testing left by the port is replaced by proper unit tests.  Some "integration" tests still left in unit tests, but this is intentional, as completely mocking out what is required to make it a truly isolated unit test is not worth it at this time.

Closes #104.